### PR TITLE
Drop ajv-cli, validate with ajv directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "astro": "^7.2.6"
       },
       "devDependencies": {
-        "ajv-cli": "^5.0.0",
+        "ajv": "^8.17.1",
         "ajv-formats": "^2.1.1"
       }
     },
@@ -1968,33 +1968,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-cli": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
-      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0",
-        "fast-json-patch": "^2.0.0",
-        "glob": "^7.1.0",
-        "js-yaml": "^3.14.0",
-        "json-schema-migrate": "^2.0.0",
-        "json5": "^2.1.3",
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "ajv": "dist/index.js"
-      },
-      "peerDependencies": {
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -2063,16 +2036,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/aria-query": {
@@ -2215,29 +2178,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2369,13 +2314,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "2.0.1",
@@ -2660,20 +2598,6 @@
         "@esbuild/win32-x64": "0.28.2"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -2690,26 +2614,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-json-patch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
-      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2815,13 +2719,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2856,28 +2753,6 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -2969,25 +2844,6 @@
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -3024,49 +2880,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json-schema-migrate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
-      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
@@ -3481,29 +3300,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -3616,16 +3412,6 @@
       "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
       "license": "MIT"
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
@@ -3691,16 +3477,6 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
       "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -4041,13 +3817,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4520,13 +4289,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nstarkman-space",
   "version": "0.0.0",
   "private": true,
-  "description": "nstarkman.space \u2014 website, CV database, and the CV builder.",
+  "description": "nstarkman.space — website, CV database, and the CV builder.",
   "type": "module",
   "scripts": {
     "predev": "node scripts/publish-data.mjs",
@@ -10,7 +10,7 @@
     "prebuild": "node scripts/publish-data.mjs",
     "build": "astro build",
     "preview": "astro preview",
-    "validate": "ajv validate -s schema/item.schema.json --spec=draft2020 -c ajv-formats --strict=false -d \"data/*.json\"",
+    "validate": "node scripts/validate.mjs schema/item.schema.json \"data/*.json\"",
     "test:schema": "bash scripts/test-schema.sh",
     "test:bibtex": "node scripts/test-bibtex.mjs",
     "test": "npm run test:schema && npm run test:bibtex && npm run build && npm run test:a11y",
@@ -19,7 +19,7 @@
     "test:a11y": "node scripts/test-a11y.mjs"
   },
   "devDependencies": {
-    "ajv-cli": "^5.0.0",
+    "ajv": "^8.17.1",
     "ajv-formats": "^2.1.1"
   },
   "dependencies": {

--- a/scripts/test-schema.sh
+++ b/scripts/test-schema.sh
@@ -8,37 +8,17 @@
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
-AJV=(./node_modules/.bin/ajv validate -s schema/item.schema.json
-     --spec=draft2020 -c ajv-formats --strict=false -d)
+AJV=(node scripts/validate.mjs schema/item.schema.json)
 
 fails=0
 
 echo "positive — data/ must validate"
-# One ajv process over the whole glob: at ~170 items, a process per file took
-# minutes. Only fall back to per-file when something is actually wrong, so the
-# failure still names the file.
-if "${AJV[@]}" "data/*.json" >/dev/null 2>&1; then
-  echo "  ok       all $(ls data/*.json | wc -l | tr -d ' ') items validate"
-else
-  for f in data/*.json; do
-    if ! "${AJV[@]}" "$f" >/dev/null 2>&1; then
-      echo "  FAILED   $f"
-      "${AJV[@]}" "$f" 2>&1 | sed 's/^/           /' | tail -3
-      fails=$((fails + 1))
-    fi
-  done
-fi
+"${AJV[@]}" "data/*.json" || fails=$((fails + 1))
 
 echo
 echo "lists — data/lists/ must validate against schema/list.schema.json"
-LIST_AJV=(./node_modules/.bin/ajv validate -s schema/list.schema.json
-          --spec=draft2020 -c ajv-formats --strict=false -d)
-if "${LIST_AJV[@]}" "data/lists/*.json" >/dev/null 2>&1; then
-  echo "  ok       all $(ls data/lists/*.json | wc -l | tr -d ' ') lists validate"
-else
-  "${LIST_AJV[@]}" "data/lists/*.json" 2>&1 | sed 's/^/  /' | tail -5
-  fails=$((fails + 1))
-fi
+node scripts/validate.mjs schema/list.schema.json "data/lists/*.json" \
+  || fails=$((fails + 1))
 
 echo
 echo "identity — filename must be <date.start>-<id>.json"

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,56 @@
+// Validates JSON files against a JSON Schema.
+//
+// This replaced ajv-cli, which is unmaintained at 5.0.0 and pins
+// fast-json-patch ^2, carrying a prototype-pollution advisory for a diff
+// feature we never used. Calling ajv directly drops that dependency and gives
+// better failures: ajv-cli reports only the first bad file in a glob, so
+// scripts/test-schema.sh used to re-run it once per file just to name the
+// culprit.
+//
+//   node scripts/validate.mjs schema/item.schema.json "data/*.json"
+
+import fs from 'node:fs';
+import path from 'node:path';
+import Ajv from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const [schemaPath, ...globs] = process.argv.slice(2);
+if (!schemaPath || globs.length === 0) {
+  console.error('usage: validate.mjs <schema> <glob>...');
+  process.exit(2);
+}
+
+// Only the one shape the callers use: a directory and a filename pattern.
+function expand(glob) {
+  const dir = path.dirname(glob);
+  const rx = new RegExp(`^${path.basename(glob).replace(/[.]/g, '\\.').replace(/\*/g, '.*')}$`);
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).filter((f) => rx.test(f)).sort().map((f) => path.join(dir, f));
+}
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+const validate = ajv.compile(JSON.parse(fs.readFileSync(schemaPath, 'utf8')));
+
+let bad = 0;
+let seen = 0;
+for (const file of globs.flatMap(expand)) {
+  seen += 1;
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    console.log(`  INVALID JSON  ${file}: ${err.message}`);
+    bad += 1;
+    continue;
+  }
+  if (validate(data)) continue;
+  bad += 1;
+  console.log(`  FAILED   ${file}`);
+  for (const e of validate.errors.slice(0, 4)) {
+    console.log(`           ${e.instancePath || '/'} ${e.message}`);
+  }
+}
+
+if (bad === 0) console.log(`  ok       all ${seen} file(s) validate`);
+process.exit(bad ? 1 : 0);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -20,12 +20,24 @@ if (!schemaPath || globs.length === 0) {
   process.exit(2);
 }
 
-// Only the one shape the callers use: a directory and a filename pattern.
+// Only the one shape the callers use: a directory and a single "*" in the
+// filename, as in data/*.json.
 function expand(glob) {
   const dir = path.dirname(glob);
-  const rx = new RegExp(`^${path.basename(glob).replace(/[.]/g, '\\.').replace(/\*/g, '.*')}$`);
+  const base = path.basename(glob);
+  const star = base.indexOf('*');
+  if (star !== base.lastIndexOf('*')) {
+    throw new Error(`Only one "*" is supported: ${glob}`);
+  }
+  const head = star === -1 ? base : base.slice(0, star);
+  const tail = star === -1 ? '' : base.slice(star + 1);
+  const matches = (f) =>
+    star === -1
+      ? f === base
+      : f.length >= head.length + tail.length && f.startsWith(head) && f.endsWith(tail);
+
   if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir).filter((f) => rx.test(f)).sort().map((f) => path.join(dir, f));
+  return fs.readdirSync(dir).filter(matches).sort().map((f) => path.join(dir, f));
 }
 
 const ajv = new Ajv({ allErrors: true, strict: false });


### PR DESCRIPTION
Closes the high-severity prototype-pollution advisory GitHub flagged on the default branch.

**Where it came from.** `fast-json-patch` arrives through `ajv-cli`, which is unmaintained at 5.0.0 and pins `^2`, so `npm audit fix` cannot reach it. It is there for a `--changes` diff feature this repo never used.

**Nothing was ever shipped.** `ajv-cli` is a devDependency; none of it reaches the browser. But it would have kept nagging.

**Fix.** `scripts/validate.mjs` calls `ajv` directly. That removes the dependency and reports better — `ajv-cli` names only the first bad file in a glob, so `test-schema.sh` re-ran it once per file just to identify the culprit. That loop is gone:

```
FAILED   data/2024-mit-postdoc.json
         /type must be equal to one of the allowed values
         / must NOT have unevaluated properties
```

All 176 items and 1 list validate, all 12 invalid fixtures still rejected, `npm audit`: **0 vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)