### PR TITLE
Complete the Potamides author list from ADS

### DIFF
--- a/data/2026-05-potamides-apj.json
+++ b/data/2026-05-potamides-apj.json
@@ -23,6 +23,22 @@
       "given": "Nathaniel",
       "me": true,
       "orcid": "0000-0003-3954-3291"
+    },
+    {
+      "family": "Pearson",
+      "given": "Sarah"
+    },
+    {
+      "family": "Nibauer",
+      "given": "Jacob"
+    },
+    {
+      "family": "Miro-Carretero",
+      "given": "Juan"
+    },
+    {
+      "family": "Martinez-Delgado",
+      "given": "David"
     }
   ],
   "venue": {
@@ -34,7 +50,6 @@
     "streams",
     "dark-matter"
   ],
-  "internal": "CV lists 'et al.'; the remaining authors are still to be imported from ADS.",
   "citekey": "Wu+:2026:potamides-halo-shapes",
   "abstract": "Stellar streams trace the gravitational potential of their host galaxies and offer a direct probe of dark matter halo geometry. Cosmological simulations predict that halo shapes depend on both baryonic physics and the nature of dark matter, yet observational constraints on halo flattening and orientation remain limited, especially for individual galaxies. We present Potamides, which utilizes the curvature of extragalactic stellar streams to derive constraints on halo shapes. We apply Potamides to 15 stellar streams from the Stellar Stream Legacy Survey to infer the projected axis ratios and orientation of their host halos. We find that some streams in our sample exclude large regions of halo flattenings and halo orientations. Systems with edge-on wrapping loops or sharp turning points yield the strongest constraints, whereas great circle-like streams remain largely uninformative. All streams in our sample support a spherical halo for a given flattening direction. These results demonstrate that stream morphology can provide halo shape constraints for individual external galaxies. With upcoming surveys (such as Euclid, Rubin, Roman, and ARRAKIHS) expected to discover large numbers of stellar streams, this curvature-based technique will enable rapid statistical tests of dark matter and baryonic physics through the shapes and alignments of halos and disks across cosmic time."
 }


### PR DESCRIPTION
The record carried **two of six** authors, with an `internal` note admitting it:

> CV lists 'et al.'; the remaining authors are still to be imported from ADS.

From [ADS 2026arXiv260507809W](https://ui.adsabs.harvard.edu/abs/2026arXiv260507809W/abstract):

> Wu, Sirui; Starkman, Nathaniel; Pearson, Sarah; Nibauer, Jacob; Miro-Carretero, Juan; Martinez-Delgado, David

All six are in the record now, in order, and the stale note is gone. The CV byline reads in full rather than stopping at "et al.", and `publications.bib` gains the four missing authors.

## On "published" — I could not confirm it

You said it has been published, but every source I checked says otherwise, so I left `status: submitted` rather than assert something I cannot support:

- ADS has **one** record for this paper, `2026arXiv260507809W`, and its Publication field reads `eprint arXiv:2605.07809`. A title search returns no journal record.
- Its DOI is `10.48550/arXiv.2605.07809` — the arXiv DOI, not a journal one.
- The arXiv metadata carries no `journal_ref` and its comment still reads "Submitted to ApJ".

If it has been accepted since ADS last indexed it, send me the journal DOI or the published bibcode and I will set the status, volume and pages in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)