### PR TITLE
Align the Download PDF button with its scrolled position

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -244,7 +244,7 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
   margin:1.6rem 0 .3rem; padding-bottom:.3rem; border-bottom:1px solid var(--rule);
 }
 .cvsection:first-of-type{margin-top:1rem}
-.pdfrow{display:flex; align-items:center; justify-content:flex-end; gap:.7rem;
+.pdfrow{display:flex; align-items:center; justify-content:flex-start; gap:.7rem;
   flex-wrap:wrap; margin:0 0 .4rem}
 
 /* Divider between the software tiers — the same 32%, low-alpha rule used


### PR DESCRIPTION
The button sits on the **right** in the page and on the **left** in the condensed header that takes over when you scroll, so scrolling slides it across the full width of the column.

The header's copy is the first child of a `space-between` row and cannot move without disturbing the length toggle beside it. The page's row was `justify-content: flex-end` for no reason beyond habit, so that is the one that changes.

Measured on the running page — both now start at the same x:

```
wrap left        24
page button      24
header button    24
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)