### PR TITLE
Clear the two CodeQL alerts on master

### DIFF
--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -12,6 +12,9 @@ on:
     paths: ["data/**", "schema/**", "src/lib/**", "scripts/**", "package.json"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   schema:
     runs-on: ubuntu-latest

--- a/src/lib/bibtex.js
+++ b/src/lib/bibtex.js
@@ -7,25 +7,35 @@
 const MONTHS = ['jan', 'feb', 'mar', 'apr', 'may', 'jun',
                 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
 
+// TeX spells its own dashes; a literal em dash breaks a pdflatex run that has
+// not been told the input is UTF-8.
+const TEX = {
+  "\\": "\\textbackslash{}",
+  "&": "\\&",
+  "%": "\\%",
+  "$": "\\$",
+  "#": "\\#",
+  "_": "\\_",
+  "{": "\\{",
+  "}": "\\}",
+  "~": "\\textasciitilde{}",
+  "^": "\\textasciicircum{}",
+  "—": "---",
+  "–": "--",
+};
+
 /**
  * Escape the characters that are syntax in TeX.
  *
- * The backslash is parked on a sentinel first: replacing it with
- * `\textbackslash{}` up front meant the brace pass then escaped that command's
- * own braces, turning `\star` into `\textbackslash\{\}star`.
+ * One pass, so every character of the input is replaced exactly once and no
+ * replacement can be re-escaped by a later step. The chained version needed a
+ * sentinel to hold the backslash — otherwise the brace pass escaped
+ * `\textbackslash{}`'s own braces and turned `\star` into
+ * `\textbackslash\{\}star` — and that sentinel was itself a hole: a NUL in the
+ * input came back out as a backslash.
  */
 function esc(value) {
-  const SENTINEL = "\u0000";
-  return String(value)
-    .replace(/\\/g, SENTINEL)
-    .replace(/([&%$#_{}])/g, "\\$1")
-    .replace(/~/g, "\\textasciitilde{}")
-    .replace(/\^/g, "\\textasciicircum{}")
-    // TeX spells its own dashes; a literal em dash breaks a pdflatex run that
-    // has not been told the input is UTF-8.
-    .replace(/\u2014/g, "---")
-    .replace(/\u2013/g, "--")
-    .replaceAll(SENTINEL, "\\textbackslash{}");
+  return String(value).replace(/[\\&%$#_{}~^–—]/g, (ch) => TEX[ch]);
 }
 
 /**


### PR DESCRIPTION
Both open alerts on the default branch.

## `js/incomplete-sanitization` — high — `src/lib/bibtex.js:19`

`esc()` escaped TeX syntax in chained passes, and the backslash had to be parked on a NUL sentinel to survive: replacing it with `\textbackslash{}` up front meant the *brace* pass then escaped that command's own braces, turning `\star` into `\textbackslash\{\}star`.

The sentinel was a hole of its own — **a NUL character in the input came back out as a backslash.**

It is one pass now, driven by a character-to-replacement map, so every character of the input is replaced exactly once and no replacement can be re-escaped by a later step. No sentinel, no ordering hazard.

```
"\\star"      ->  "\\textbackslash{}star"
"{braced}"    ->  "\\{braced\\}"
"em — dash"   ->  "em --- dash"
"ab"    ->  "ab"        <- previously "a\\textbackslash{}b"
```

`publications.bib` is byte-identical to master, and the eleven bibtex assertions still pass.

## `actions/missing-workflow-permissions` — medium — `.github/workflows/validate-data.yml:17`

The job checks out the repo and runs the schema tests; it writes nothing. `contents: read` rather than whatever the default grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
