### PR TITLE
Point the workflows at main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,14 +5,14 @@ name: Deploy site
 # asset directory. So the Pages Source must be "GitHub Actions".
 #
 # Deployment only. Pull requests are gated by ci.yml, which runs the same build
-# plus the tests; this workflow exists to publish what lands on master.
+# plus the tests; this workflow exists to publish what lands on main.
 #
 # withastro/action is deliberately not used: it builds and uploads in one step,
 # and the CV PDFs have to be compiled into dist/ in between.
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -54,7 +54,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -95,7 +95,7 @@ jobs:
           # Already exists is the normal case and not an error.
           command: >-
             pages project create nstarkman-space
-            --production-branch=master
+            --production-branch=main
         continue-on-error: true
 
       - if: steps.guard.outputs.ready == 'true'


### PR DESCRIPTION
Follow-up to the default branch rename. `git grep -w master` is now empty in this repo.

| file | was | why it mattered |
|---|---|---|
| `ci.yml:12` | `branches: [master]` | never fires on pushes to `main` |
| `deploy.yml:15` | `branches: [master]` | same, so nothing publishes |
| `deploy.yml:57` | `if: github.ref == 'refs/heads/master'` | **skips** the deploy job — green tick, nothing published |
| `preview.yml:98` | `--production-branch=master` | inert (only read at project creation), corrected anyway |

The guard on `deploy.yml:57` is now `github.ref_name == github.event.repository.default_branch` rather than a second literal `main`. It had already drifted from the trigger above it once; a symbolic comparison follows the next rename on its own, as the branch ruleset does.

Verified locally: build ok, 70 unit tests, 780 links, 776 anchors, a11y across 9 pages.

The proof this actually works is the deploy job **running** rather than skipping on the merge push — I'll check that rather than trusting the green tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)