### PR TITLE
Make Jekyll structurally impossible, not just switched off

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,11 @@
 name: Deploy site
 
-# Astro builds to dist/, and a branch deploy would (a) require committing build
-# output and (b) run the artifact through Jekyll, which strips Astro's _astro/
-# asset directory. So the Pages Source must be "GitHub Actions".
+# Astro builds to dist/, so a branch deploy would require committing build
+# output; the Pages Source is "GitHub Actions" and the repo holds no Jekyll.
+# public/.nojekyll backs that up rather than relying on the setting staying
+# put: Jekyll strips underscore-prefixed directories, which would take Astro's
+# whole _astro/ asset tree with it and unstyle the site without failing a
+# build. scripts/test-links.mjs asserts the file is in every artifact.
 #
 # Deployment only. Pull requests are gated by ci.yml, which runs the same build
 # plus the tests; this workflow exists to publish what lands on main.

--- a/README.md
+++ b/README.md
@@ -38,10 +38,17 @@ npm run build:all  # the site, then the four CV PDFs (needs typst)
 
 ## Deployment
 
-GitHub Pages via Actions (`.github/workflows/deploy.yml`), not a branch deploy —
-Astro emits assets into `_astro/`, and a branch deploy pipes the artifact
-through Jekyll, which strips underscore-prefixed directories. `public/CNAME`
-ships the custom domain in the artifact so it survives every deploy.
+GitHub Pages via Actions (`.github/workflows/deploy.yml`), not a branch deploy:
+Astro builds to `dist/`, which a branch deploy would mean committing.
+
+`public/` carries two files that exist only to survive into the artifact:
+
+- **`CNAME`** — the custom domain, so it is reapplied on every deploy.
+- **`.nojekyll`** — Jekyll strips underscore-prefixed directories, and Astro
+  emits every asset into `_astro/`. Nothing runs Jekyll today, but the failure
+  mode if anything ever did is a site that returns 200 on every page with no
+  CSS and no build failure to notice. `scripts/test-links.mjs` fails the build
+  if the file is missing from `dist/`.
 
 ## History
 

--- a/scripts/test-links.mjs
+++ b/scripts/test-links.mjs
@@ -30,6 +30,18 @@ function walk(dir, out = []) {
 const files = new Set(walk(DIST));
 const pages = [...files].filter((f) => f.endsWith('.html'));
 
+// Astro emits every asset into _astro/, and Jekyll deletes underscore-prefixed
+// directories — so if Pages ever processed this artifact the site would come
+// back styleless with no build failure to notice. public/.nojekyll is what
+// stops that, in any Pages mode. It is one empty file that nothing references,
+// which is exactly the kind of thing a tidy-up deletes, so it is asserted here
+// rather than trusted.
+if (!files.has('/.nojekyll')) {
+  console.error('  MISSING        /.nojekyll — restore public/.nojekyll');
+  console.error('                 without it Jekyll may strip _astro/ and unstyle the site');
+  process.exit(1);
+}
+
 /** Does a site-absolute href exist in the build? */
 function exists(href) {
   if (files.has(href)) return true;


### PR DESCRIPTION
The repo holds no Jekyll and Pages is set to build from Actions — but nothing *enforced* that. The safeguard was a comment in `deploy.yml` reading "the Pages Source must be GitHub Actions".

That matters because of how it would fail. Jekyll strips underscore-prefixed directories, and Astro emits every asset into `_astro/`. If anything ever processed this artifact the result is not a broken build — it is **every page returning 200 with no CSS**, and nothing red anywhere to notice it.

## The fix

`public/.nojekyll` — one empty file, copied into `dist/` by Astro and into the artifact by `upload-pages-artifact`. It rules Jekyll out in *any* Pages mode, so the setting no longer has to be remembered.

## Why it also needs a test

An empty file that nothing imports and nothing links to is exactly what a tidy-up deletes. `scripts/test-links.mjs` already walks `dist/`, so the assertion costs nothing there. Confirmed it bites:

```
exit code without .nojekyll: 1
exit code with .nojekyll:    0
```

## Also

`deploy.yml` and `README.md` described the hazard as a rule to follow. They now describe the guarantee and where it is enforced.

Verified: 70 unit tests, 780 links, 776 anchors, a11y across 9 pages, schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)