### PR TITLE
Guard the setting Jekyll actually depends on, and drop the file that did not

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,12 @@
 name: Deploy site
 
-# Astro builds to dist/, so a branch deploy would require committing build
-# output; the Pages Source is "GitHub Actions" and the repo holds no Jekyll.
-# public/.nojekyll backs that up rather than relying on the setting staying
-# put: Jekyll strips underscore-prefixed directories, which would take Astro's
-# whole _astro/ asset tree with it and unstyle the site without failing a
-# build. scripts/test-links.mjs asserts the file is in every artifact.
+# Astro builds to dist/, so a branch deploy would mean committing build output
+# — and would serve the repo source rather than the built site. The Pages
+# Source is "GitHub Actions", which serves the artifact verbatim and never
+# invokes Jekyll, so Astro's underscore-prefixed _astro/ survives. A .nojekyll
+# would be redundant, and could not ship anyway: upload-pages-artifact strips
+# every dotfile from the tarball. The build_type check below is what actually
+# holds that guarantee in place.
 #
 # Deployment only. Pull requests are gated by ci.yml, which runs the same build
 # plus the tests; this workflow exists to publish what lands on main.
@@ -49,6 +50,23 @@ jobs:
           typst-version: "0.15.1"
       # one PDF per preset, compiled from the models Astro just emitted
       - run: npm run build:pdf
+
+      # The one setting this all rests on, and it lives in the web UI where
+      # nothing else can see it drift. Flipped to "Deploy from a branch", Pages
+      # would build the repo root with Jekyll — which strips _astro/ — and the
+      # site would go out styleless. Checked before the artifact is built
+      # rather than discovered afterwards by looking at it.
+      - name: Pages must still build from Actions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bt=$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq .build_type)
+          [ "$bt" = workflow ] || {
+            echo "::error::Pages build_type is '$bt', expected 'workflow'." \
+                 "Settings -> Pages -> Source must be GitHub Actions."
+            exit 1
+          }
+          echo "  Pages build_type=$bt"
 
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v4

--- a/README.md
+++ b/README.md
@@ -39,16 +39,22 @@ npm run build:all  # the site, then the four CV PDFs (needs typst)
 ## Deployment
 
 GitHub Pages via Actions (`.github/workflows/deploy.yml`), not a branch deploy:
-Astro builds to `dist/`, which a branch deploy would mean committing.
+Astro builds to `dist/`, which a branch deploy would mean committing — and
+would publish the repo source instead of the built site.
 
-`public/` carries two files that exist only to survive into the artifact:
+`public/CNAME` ships the custom domain in the artifact so it survives every
+deploy.
 
-- **`CNAME`** — the custom domain, so it is reapplied on every deploy.
-- **`.nojekyll`** — Jekyll strips underscore-prefixed directories, and Astro
-  emits every asset into `_astro/`. Nothing runs Jekyll today, but the failure
-  mode if anything ever did is a site that returns 200 on every page with no
-  CSS and no build failure to notice. `scripts/test-links.mjs` fails the build
-  if the file is missing from `dist/`.
+**Jekyll never runs.** Source "GitHub Actions" serves the uploaded artifact
+verbatim, so Astro's underscore-prefixed `_astro/` is untouched — the live site
+serves it while no `.nojekyll` exists anywhere, which is the proof. A
+`.nojekyll` would also be unshippable: `upload-pages-artifact` strips every
+dotfile from the tarball.
+
+That leaves one thing holding the guarantee up, and it lives in the web UI
+where nothing in the repo can see it change. So `deploy.yml` asserts
+`build_type == workflow` against the API before it builds, and fails with the
+setting to correct rather than publishing a styleless site.
 
 ## History
 

--- a/scripts/test-links.mjs
+++ b/scripts/test-links.mjs
@@ -30,18 +30,6 @@ function walk(dir, out = []) {
 const files = new Set(walk(DIST));
 const pages = [...files].filter((f) => f.endsWith('.html'));
 
-// Astro emits every asset into _astro/, and Jekyll deletes underscore-prefixed
-// directories — so if Pages ever processed this artifact the site would come
-// back styleless with no build failure to notice. public/.nojekyll is what
-// stops that, in any Pages mode. It is one empty file that nothing references,
-// which is exactly the kind of thing a tidy-up deletes, so it is asserted here
-// rather than trusted.
-if (!files.has('/.nojekyll')) {
-  console.error('  MISSING        /.nojekyll — restore public/.nojekyll');
-  console.error('                 without it Jekyll may strip _astro/ and unstyle the site');
-  process.exit(1);
-}
-
 /** Does a site-absolute href exist in the build? */
 function exists(href) {
   if (files.has(href)) return true;


### PR DESCRIPTION
Corrects #10, which I got wrong. Worth reading for the failure mode as much as the fix.

## #10 did not work

The `.nojekyll` it added **never reached production**. `upload-pages-artifact` strips every dotfile from the tarball — the deployed artifact contains no `.nojekyll` at all, while `CNAME`, sitting beside it in `public/` and not hidden, survives:

```
$ tar -tf artifact.tar | grep -E "/\.[^/]+$"      # (nothing)
$ curl -o /dev/null -w '%{http_code}' https://nstarkman.space/.nojekyll
404
```

The test I added asserted the file was in `dist/` — which is *upstream* of the strip. So it passed, stayed green, and proved nothing. A test that cannot fail for the reason it exists is worse than no test, because it reads as coverage.

## It was also unnecessary

```
$ curl -o /dev/null -w '%{http_code} %{content_type}' https://nstarkman.space/_astro/Base.C7eZCK2e.css
200 text/css; charset=utf-8
```

`_astro/` served, no `.nojekyll` anywhere. That is a direct demonstration that Source "GitHub Actions" hands the artifact over verbatim and never invokes Jekyll.

## What actually holds the guarantee

`build_type == workflow`. It lives in the web UI, where nothing in the repo can see it drift, and flipping it is the *only* way Jekyll gets near this site. So `deploy.yml` checks it against the API before building:

```
bt=$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq .build_type)
[ "$bt" = workflow ] || { echo "::error::Pages build_type is '$bt'…"; exit 1; }
```

Verified both branches locally against the real API — passes on `workflow`, fails on `legacy`. `pages: write` already in `permissions` covers the read.

The failure becomes a red run naming the setting to fix, instead of a live site that returns 200 on every page with no CSS.

Verified: 70 unit tests, 780 links, 776 anchors, a11y across 9 pages, schema, and `deploy.yml` parses with the expected 10 build steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)