### PR TITLE
Move every action onto its Node 24 major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -49,7 +49,7 @@ jobs:
       - name: Accessibility
         run: npm run test:a11y
 
-      - uses: typst-community/setup-typst@v4
+      - uses: typst-community/setup-typst@v5
         with:
           typst-version: "0.15.1"
 
@@ -61,7 +61,7 @@ jobs:
       - name: Links
         run: npm run test:links
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: site
           path: dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -45,7 +45,7 @@ jobs:
 
       - run: npm run build
 
-      - uses: typst-community/setup-typst@v4
+      - uses: typst-community/setup-typst@v5
         with:
           typst-version: "0.15.1"
       # one PDF per preset, compiled from the models Astro just emitted
@@ -68,8 +68,8 @@ jobs:
           }
           echo "  Pages build_type=$bt"
 
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,9 +51,9 @@ jobs:
           fi
 
       - if: steps.guard.outputs.ready == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - if: steps.guard.outputs.ready == 'true'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -66,7 +66,7 @@ jobs:
       # The CV PDFs are part of the site; a preview without them would 404 on
       # every Download button.
       - if: steps.guard.outputs.ready == 'true'
-        uses: typst-community/setup-typst@v4
+        uses: typst-community/setup-typst@v5
         with:
           typst-version: "0.15.1"
       - if: steps.guard.outputs.ready == 'true'
@@ -88,7 +88,7 @@ jobs:
 
       - if: steps.guard.outputs.ready == 'true'
         name: Ensure the Pages project exists
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -100,7 +100,7 @@ jobs:
 
       - if: steps.guard.outputs.ready == 'true'
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -112,7 +112,7 @@ jobs:
             --commit-dirty=true
 
       - if: steps.guard.outputs.ready == 'true'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: preview
           message: |


### PR DESCRIPTION
Every run has been warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/configure-pages@v5`, `actions/setup-node@v4`, `typst-community/setup-typst@v4`

Being force-run on a runtime they were never tested against is the part worth fixing — the deprecation notice is just how we found out.

| action | was | now |
|---|---|---|
| `actions/checkout` | v4 / v5 | **v7** |
| `actions/setup-node` | v4 / v5 | **v7** |
| `typst-community/setup-typst` | v4 | **v5** |
| `actions/configure-pages` | v5 | **v6** |
| `actions/upload-pages-artifact` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v7** |
| `cloudflare/wrangler-action` | v3 | **v4** |
| `marocchino/sticky-pull-request-comment` | v2 | **v3** |

`actions/deploy-pages@v5` was already current.

## The two with real breaking changes

**`setup-typst` v5** drops the `local-packages` input and *all* outputs. We use neither. It keeps `typst-version`, so **0.15.1 stays pinned** — which matters, because the CV build asserts 1P is one page and 2P is two, and those contracts only hold against a known compiler.

**`wrangler-action` v4** changes the default Wrangler from v3 to v4. The preview job on this PR exercises it end to end — project check, upload, sticky comment.

## Coverage gap I closed by hand

`ci.yml` and `preview.yml` are exercised by this PR, but `deploy.yml`'s Pages chain — `configure-pages@v6` and `upload-pages-artifact@v5` — normally only runs on `main`, i.e. after merge. So I dispatched `deploy.yml` on this branch: its `build` job runs both actions for real, while the `deploy` job correctly skips, being gated to the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)