### PR TITLE
Set the CV's figures old-style, keeping columns and identifiers lining

### DIFF
--- a/cv/cv.typ
+++ b/cv/cv.typ
@@ -38,7 +38,29 @@
 )
 // New Computer Modern is Typst's own, so CI and the browser both have it — and
 // it is Latin Modern's successor, the face the LaTeX CV was already set in.
-#set text(font: "New Computer Modern", size: 11pt, fill: ink, lang: "en")
+#set text(
+  font: "New Computer Modern",
+  size: 11pt,
+  fill: ink,
+  lang: "en",
+  // A CV is mostly numbers set inside sentences — years, volumes, pages. Lining
+  // figures are cap-height, so each one reads as a small block of capitals
+  // interrupting the line. Old-style figures carry ascenders and descenders and
+  // sit in the text the way lowercase does. Columns of digits want the opposite
+  // treatment and get it back individually below; #tnum is the helper.
+  number-type: "old-style",
+)
+
+// Lining and tabular: equal-width, cap-height digits, for the places where
+// figures form a column and have to align down the page rather than read as
+// part of a sentence.
+#let tnum(body) = text(number-type: "lining", number-width: "tabular", body)
+
+// Lining but proportional, for identifiers rather than columns. An ORCID iD, an
+// arXiv number or a postcode is transcribed digit by digit rather than read as
+// a quantity, and old-style figures — which vary in height by design — make
+// that harder for no gain.
+#let lnum(body) = text(number-type: "lining", body)
 #set par(
   justify: true,
   spacing: 0pt,
@@ -136,7 +158,9 @@
 
   {
     set par(justify: false, leading: 0.38em)
-    set text(size: 8.9pt)
+    // Every figure in this column is transcription data — street number,
+    // postcode, ORCID iD — so the whole block stays lining.
+    set text(size: 8.9pt, number-type: "lining")
     p.addressLines.join(linebreak())
     linebreak()
     link("mailto:" + p.email)[#icon("email", size: 0.9em) #p.email]
@@ -219,9 +243,9 @@
     align: (left + top, left + top, right + top),
     ..items
       .map(it => (
-        text(size: 10.1pt)[#it.when],
+        tnum(text(size: 10.1pt)[#it.when]),
         entrybody(it),
-        text(size: 10.1pt)[#it.trailing],
+        tnum(text(size: 10.1pt)[#it.trailing]),
       ))
       .flatten(),
   )
@@ -235,7 +259,7 @@
     columns: (1.6em, 1fr),
     column-gutter: 4pt,
     align: (right + top, left + top),
-    text(size: 10.1pt)[#n.],
+    tnum(text(size: 10.1pt)[#n.]),
     {
       if it.byline.len() > 0 [#bolded(it.byline). ]
       emph(it.title)
@@ -249,7 +273,7 @@
         .map(l => if l.label == l.rel {
           link(l.url, icon(l.icon, size: 0.9em))
         } else {
-          link(l.url, [#icon(l.icon, size: 0.9em) #l.label])
+          link(l.url, [#icon(l.icon, size: 0.9em) #lnum(l.label)])
         })
         .join(h(5pt))
       if cite.len() > 0 [ #cited]


### PR DESCRIPTION
A CV is mostly numbers set inside sentences — years, volumes, pages. Lining figures are cap-height, so each one reads as a small block of capitals interrupting the line. Old-style figures carry ascenders and descenders and sit in text the way lowercase does.

New Computer Modern already ships `onum` and `tnum`:

```
NewCM10-Regular  smcp=True  c2sc=True  onum=True  tnum=True
```

So this is a feature that was there the whole time and never switched on. No new fonts, no new files, nothing vendored.

## Where it does *not* apply

Three contexts want the opposite treatment, and they get it back individually via two helpers:

| context | treatment | why |
|---|---|---|
| date gutter, trailing column, publication numbers | **lining + tabular** (`tnum`) | they are columns and must align down the page |
| ORCID iD, arXiv numbers, DOIs, postcode | **lining, proportional** (`lnum`) | transcribed digit by digit, not read as quantities |
| everything else | old-style | running text |

Getting this wrong is what makes old-style figures look like a mistake rather than a refinement — an ORCID iD in old-style is actively harder to copy.

## Verified by looking at it

Rendered before/after at 150 and 400 dpi and compared regions directly:

- **Body** — `Monthly Notices of the Royal Astronomical Society 529, 2274` now sits in the line instead of standing up. `GPA 4.0`, `2020–2023`, `(v5.0)` likewise.
- **Date gutter** — `2018 – 2024`, `2024 – 2027` pixel-identical to before.
- **Header** — address, postcode and `0000-0003-3954-3291` pixel-identical to before.
- **Publications** — `10.1093/mnras/stae665`, `arXiv:2206.14220` and the list numbers pixel-identical to before.

I also checked an apparent ampersand change at low resolution; at 400 dpi the glyph is identical — it was antialiasing.

## Both runtimes agree

`cv.typ` compiles twice: the CLI at 0.15.1 in CI, and typst.ts 0.7 WASM in `/cv/builder/`. An older in-browser compiler rejecting `number-type` would have silently split the downloadable PDF from the browser-built one. Ran the builder against this change: **Built 96 entries · 321 KB**, no error.

Page contracts hold (1P one page, 2P two), 70 unit tests, 780 links, 776 anchors, a11y across 9 pages, schema. `pdffonts` shows the same six embedded fonts as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)