### PR TITLE
Drop the not-shown count from the PDF

### DIFF
--- a/cv/cv.typ
+++ b/cv/cv.typ
@@ -152,17 +152,13 @@
 // ── headings ──────────────────────────────────────────────────────────────
 // \titleformat{\section}{\Large\scshape\raggedright}{}{0em}{}[\titlerule]
 // \titlespacing{\section}{0pt}{10pt}{10pt}, \titlerule default 0.4pt.
-#let section(title, mark: none, note: none) = {
+#let section(title, mark: none) = {
   v(if tight { 6pt } else { 9.2pt })
   block(breakable: false, sticky: true)[
     #set par(justify: false, spacing: 0pt)
     #text(size: 15.6pt)[
       #if mark != none [#icon(mark, size: 0.95em, fill: ink) #h(2pt)]
       #smallcaps(title)
-    ]
-    #if note != none [
-      #h(1fr)
-      #text(size: 8.6pt, fill: faint)[#note]
     ]
     #v(4.5pt)
     #line(length: 100%, stroke: 0.4pt + ink)
@@ -316,7 +312,6 @@
   section(
     s.heading,
     mark: s.at("icon", default: none),
-    note: if s.dropped > 0 { [#s.dropped more not shown.] } else { none },
   )
   if "layout" in s and s.layout == "list" {
     plainlist(s.entries)


### PR DESCRIPTION
The `N more not shown.` note is right on the website — the CV page is one view of a larger database, and the note tells you a fuller list is a click away. A PDF is a finished document: the recipient has nothing to click, so it only advertises that they are holding an abridged copy.

## What changed

`cv.typ` was the only place it reached a PDF, via the `note:` argument on `section()`. That call site was also the *only* caller passing `note:`, so the parameter and its rendering branch had no remaining use and go with it rather than sitting unreachable.

**The website is untouched** — `cvmodel.js:133` still emits `dropped` and [CvView.astro:194](src/components/CvView.astro:194) still renders it.

## Verified

```
starkman-cv-1page.pdf        0 occurrence(s)
starkman-cv-2page.pdf        0 occurrence(s)
starkman-cv-complete.pdf     0 occurrence(s)
starkman-cv-np.pdf           0 occurrence(s)
dist/cv/index.html:          1
```

Checked the rendered heading too, in case removing it left a gap: the note sat on the heading line pushed right by `h(1fr)`, so the vertical rhythm is identical and the rule still runs full measure.

Page contracts hold (1P one page, 2P two), 70 unit tests, 780 links, 776 anchors, a11y across 9 pages, schema.

> Note: this branches off `main` alongside #13. Both touch `cv.typ` but in different regions — #13 is the figure settings and the entry/publication rows, this is `section()` — so they merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)