### PR TITLE
Feature the PINNs paper on the home page instead of the stream-paths one

### DIFF
--- a/data/2023-04-characterizing-stream-tracks.json
+++ b/data/2023-04-characterizing-stream-tracks.json
@@ -7,7 +7,6 @@
     "2page",
     "1page"
   ],
-  "featured": true,
   "date": {
     "start": "2023-04"
   },

--- a/data/2026-06-pinns-mnras.json
+++ b/data/2026-06-pinns-mnras.json
@@ -7,6 +7,7 @@
     "2page",
     "1page"
   ],
+  "featured": true,
   "date": {
     "start": "2026-06"
   },


### PR DESCRIPTION
Swaps one `featured` flag: *On the fast track: Rapid construction of stellar stream paths* comes off Selected Publications, and Charlotte Myers' *Physics-Informed Neural Networks for Modeling Galactic Gravitational Potentials* goes on.

```
 data/2023-04-characterizing-stream-tracks.json | 1 -
 data/2026-06-pinns-mnras.json                  | 1 +
```

## Home page after

```
1. Euclid Quick Data Release (Q1) …                          2026, submitted
2. Physics-Informed Neural Networks …  C. Myers, N. Starkman, L. Necib, MNRAS, submitted
3. unxt: A Python package for unit-aware computing with JAX  2025
4. Stream Members Only …                                     2025
5. Angular Correlations of CMB Spectrum Distortions …        2024
```

The list is `featured(...).slice(0, 5)` and exactly five records carry the flag, so the swap is one-in-one-out and PINNs lands second by date.

## Two scope notes

**The CV PDFs are unchanged.** The presets select on `cvs`, not `featured` — verified all three lists are byte-identical, and *On the fast track* keeps its place on 1P/2P/NP.

**The profile README follows.** `nstarman/nstarman`'s `build_readme.py:57` reads the same `featured` flag, so its Select Publications will pick this up on the next refresh. I rendered it against this branch to confirm it comes out right rather than assuming:

```
1. Euclid Collaboration, N. Starkman, … (2026)
1. C. Myers, N. Starkman, L. Necib (2026). Physics-Informed Neural Networks …
1. N. Starkman (2025). unxt …
```

Say the word if you'd rather the README kept the old list — that would need its own selector rather than sharing `featured`.

Schema, bibtex, 70 unit tests, 780 links, 776 anchors, a11y across 9 pages all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)