### PR TITLE
Save and load a builder selection, stamped with the site's commit

### DIFF
--- a/src/components/CvHeader.astro
+++ b/src/components/CvHeader.astro
@@ -14,11 +14,19 @@ const onBuilder = current === 'builder';
       ? <a class="btn" href={pdf} tabindex="-1">Download PDF</a>
       : <span class="spacer"></span>}
     <span class="more">
-      <span class="cvtoggle cvtoggle--main">
-        {presetNames.map((n) => (
-          <a href={href(n)} class={n === current ? 'on' : ''} tabindex="-1">{preset(n).label}</a>
-        ))}
-      </span>
+      {onBuilder
+        /* Jumping to a fixed-length CV mid-build would discard the selection
+           without warning, so the condensed bar offers Save in that slot
+           instead. The lengths stay in the heading row, which means leaving
+           this page is something you scroll back up to do deliberately. */
+        ? <span class="cvtoggle cvtoggle--main">
+            <button class="btn" type="button" id="savebar" tabindex="-1">Save</button>
+          </span>
+        : <span class="cvtoggle cvtoggle--main">
+            {presetNames.map((n) => (
+              <a href={href(n)} class={n === current ? 'on' : ''} tabindex="-1">{preset(n).label}</a>
+            ))}
+          </span>}
       <span class="sep">|</span>
       <span class="cvtoggle cvtoggle--main">
         <a href="/cv/builder/" class={onBuilder ? 'build on' : 'build'} tabindex="-1">Build</a>
@@ -59,7 +67,7 @@ const onBuilder = current === 'builder';
       const on = controls.getBoundingClientRect().bottom < NAV;
       bar.classList.toggle('is-on', on);
       bar.setAttribute('aria-hidden', on ? 'false' : 'true');
-      for (const a of bar.querySelectorAll('a')) a.tabIndex = on ? 0 : -1;
+      for (const el of bar.querySelectorAll('a, button')) el.tabIndex = on ? 0 : -1;
     };
     syncBar();
     addEventListener('scroll', syncBar, { passive: true });

--- a/src/lib/buildinfo.js
+++ b/src/lib/buildinfo.js
@@ -1,0 +1,44 @@
+// Which commit the running site was built from.
+//
+// The CV builder writes this into a saved selection so a selection can be taken
+// back to the site that produced it: the database moves, entries are added and
+// re-worded, and a selection is a list of ids that only means something against
+// a particular version of the data. `git checkout <commit> && npm run build`
+// reproduces that site exactly.
+//
+// Build-time only — imported from .astro frontmatter, which runs in Node.
+
+import { execSync } from 'node:child_process';
+
+const git = (args) => {
+  try {
+    return execSync(`git ${args}`, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim();
+  } catch {
+    // Not a checkout — a source tarball, or git is unavailable.
+    return null;
+  }
+};
+
+/**
+ * `{ commit, short, dirty }`, or nulls when the commit cannot be determined.
+ *
+ * `dirty` matters as much as the commit: a local build with uncommitted changes
+ * is not reproducible from the commit alone, and saying so is better than
+ * implying the selection can be recovered when it cannot.
+ */
+export function buildInfo() {
+  // What was actually built, in preference to what CI says it checked out.
+  const commit = git('rev-parse HEAD') || process.env.GITHUB_SHA || null;
+  if (!commit) return { commit: null, short: null, dirty: false };
+  const status = git('status --porcelain');
+  return {
+    commit,
+    short: commit.slice(0, 7),
+    // null status means git failed; absence of evidence, so do not claim clean.
+    dirty: status === null ? false : status.length > 0,
+  };
+}

--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -1,0 +1,98 @@
+// The saved-selection file for the CV builder.
+//
+// A selection is a list of entry ids plus, per entry, which of its detail lines
+// are kept. That only means something against a particular version of the
+// database, so the file records the commit the site was built from: if the ids
+// no longer resolve, `git checkout <commit>` and a local build gets them back.
+//
+// Read by the builder from a file the user chose, so decode() treats its input
+// as hostile — wrong shape, wrong types, absurd sizes — and fails with a
+// sentence a person can act on rather than a TypeError from three frames down.
+
+export const FORMAT = 'starkman-cv-selection';
+export const VERSION = 1;
+
+// Nothing legitimate approaches these; they stop a malformed or malicious file
+// from being expanded into millions of DOM lookups.
+const MAX_ITEMS = 5000;
+const MAX_LINES_PER_ITEM = 500;
+
+/** The selection as it is written to disk. */
+export function encode({ items, lines, site = {}, savedAt }) {
+  const clean = {};
+  for (const [id, ns] of Object.entries(lines ?? {})) {
+    const kept = [...new Set(ns)].filter((n) => Number.isInteger(n) && n >= 0).sort((a, b) => a - b);
+    if (kept.length) clean[id] = kept;
+  }
+  return {
+    format: FORMAT,
+    version: VERSION,
+    savedAt: savedAt ?? new Date().toISOString(),
+    // What the ids mean. `dirty` says the build had uncommitted changes, so the
+    // commit alone will not reproduce it.
+    site: { commit: site.commit ?? null, short: site.short ?? null, dirty: !!site.dirty },
+    items: [...new Set(items ?? [])].filter((s) => typeof s === 'string'),
+    lines: clean,
+  };
+}
+
+class SelectionError extends Error {}
+
+const fail = (msg) => {
+  throw new SelectionError(msg);
+};
+
+/**
+ * Parse a saved selection. Throws `SelectionError` with a readable message.
+ * Returns `{ items:Set, lines:Map<string,Set<number>>, site, savedAt }`.
+ */
+export function decode(text) {
+  let raw;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    fail('That file is not JSON.');
+  }
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    fail('That file is not a saved selection.');
+  }
+  if (raw.format !== FORMAT) {
+    fail('That is not a CV selection file.');
+  }
+  // Forward compatibility is the author's problem, not the reader's: a newer
+  // file may mean things this build cannot honour, so say so rather than guess.
+  if (!Number.isInteger(raw.version) || raw.version > VERSION) {
+    fail(`That selection was saved by a newer version of this page (v${raw.version}).`);
+  }
+  if (!Array.isArray(raw.items)) fail('That selection has no entry list.');
+  if (raw.items.length > MAX_ITEMS) fail('That selection is implausibly large.');
+
+  const items = new Set(raw.items.filter((s) => typeof s === 'string'));
+
+  const lines = new Map();
+  const rawLines = raw.lines;
+  if (rawLines !== undefined) {
+    if (rawLines === null || typeof rawLines !== 'object' || Array.isArray(rawLines)) {
+      fail('That selection has a malformed detail list.');
+    }
+    for (const [id, ns] of Object.entries(rawLines)) {
+      if (!Array.isArray(ns) || ns.length > MAX_LINES_PER_ITEM) continue;
+      const kept = ns.filter((n) => Number.isInteger(n) && n >= 0);
+      if (kept.length) lines.set(id, new Set(kept));
+    }
+  }
+
+  const site = raw.site && typeof raw.site === 'object' && !Array.isArray(raw.site) ? raw.site : {};
+  return {
+    items,
+    lines,
+    savedAt: typeof raw.savedAt === 'string' ? raw.savedAt : null,
+    site: {
+      commit: typeof site.commit === 'string' ? site.commit : null,
+      short: typeof site.short === 'string' ? site.short : null,
+      dirty: !!site.dirty,
+    },
+  };
+}
+
+export { SelectionError };

--- a/src/pages/cv/builder.astro
+++ b/src/pages/cv/builder.astro
@@ -3,6 +3,7 @@ import Base from '../../layouts/Base.astro';
 import CvHeader from '../../components/CvHeader.astro';
 import CvView from '../../components/CvView.astro';
 import { resolve, memberIds, presetNames, preset } from '../../lib/presets.js';
+import { buildInfo } from '../../lib/buildinfo.js';
 
 // The picker is the complete CV itself, rendered server-side with a checkbox on
 // every entry — so what you tick is what you are about to compile, and the page
@@ -15,6 +16,8 @@ const picked = new Set(memberIds(START));
 const startLevel = preset(START).detail;
 const membership = Object.fromEntries(presetNames.map((n) => [n, memberIds(n)]));
 const total = cv.sections.reduce((n, s) => n + s.items.length, 0);
+// Stamped into a saved selection so it can be taken back to the data it names.
+const site = buildInfo();
 ---
 <Base title="CV builder — Nathaniel Starkman">
   <main>
@@ -33,8 +36,11 @@ const total = cv.sections.reduce((n, s) => n + s.items.length, 0);
           {presetNames.map((n) => (
             <button class="btn" type="button" data-preset={n}>{preset(n).label}</button>
           ))}
-          <span class="bl">·</span>
           <button class="btn" type="button" data-all="0">None</button>
+          <span class="sep">|</span>
+          <button class="btn" type="button" id="load">Load</button>
+          <input type="file" id="loadfile" accept="application/json,.json"
+                 hidden aria-hidden="true" tabindex="-1" />
           <span class="count" id="count">{picked.size} / {total}</span>
         </div>
 
@@ -59,9 +65,11 @@ const total = cv.sections.reduce((n, s) => n + s.items.length, 0);
   <script type="application/json" id="membership" set:html={JSON.stringify(membership)}></script>
   <script type="application/json" id="detaillevels"
           set:html={JSON.stringify(Object.fromEntries(presetNames.map((n) => [n, preset(n).detail])))}></script>
+  <script type="application/json" id="siteinfo" set:html={JSON.stringify(site)}></script>
 
   <script>
     import { cvModel } from '../../lib/cvmodel.js';
+    import { encode, decode } from '../../lib/selection.js';
     import typSource from '../../../cv/cv.typ?raw';
     // cv.typ draws its marks with image("icons/…"), which resolves against the
     // compilation root: cv/icons/ under the CLI, /icons/ here. Bundled at build
@@ -74,6 +82,7 @@ const total = cv.sections.reduce((n, s) => n + s.items.length, 0);
     const boxes = () => [...document.querySelectorAll('.itembox')];
     const subs = () => [...document.querySelectorAll('.subbox')];
     const DETAIL = JSON.parse(document.getElementById('detaillevels').textContent);
+    const SITE = JSON.parse(document.getElementById('siteinfo').textContent);
 
     /** An unticked line greys out in place, so the page keeps showing what it
      *  is about to compile rather than describing it. */
@@ -138,6 +147,92 @@ const total = cv.sections.reduce((n, s) => n + s.items.length, 0);
         recount();
         status(`Selection set from ${t.textContent}.`);
       }
+    });
+
+    // ── save & load ───────────────────────────────────────────────────────
+    // A long selection is real work, and it is only ever one reload from gone.
+
+    const plural = (n, one, many = one + 's') => `${n} ${n === 1 ? one : many}`;
+
+    /** What is ticked right now: entries, and which lines of each. */
+    const currentLines = () => {
+      const lines = {};
+      for (const b of subs()) {
+        if (!b.checked) continue;
+        (lines[b.dataset.id] ??= []).push(Number(b.dataset.line));
+      }
+      return lines;
+    };
+
+    const saveSelection = () => {
+      const chosen = boxes().filter((b) => b.checked).map((b) => b.value);
+      const doc = encode({ items: chosen, lines: currentLines(), site: SITE });
+      // Indented: it is small, and a selection you can read and hand-edit in a
+      // text editor is worth more than the bytes saved.
+      const blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `starkman-cv-${SITE.short ?? 'selection'}.json`;
+      a.click();
+      // Freed on the next turn: revoking synchronously can beat the download.
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+      status(`Saved ${plural(chosen.length, 'entry', 'entries')}${SITE.short ? ` from ${SITE.short}` : ''}.`);
+    };
+
+    /** Tick what the file says, and report anything the current data cannot. */
+    const applySelection = (sel) => {
+      const known = new Set(boxes().map((b) => b.value));
+      const missing = [...sel.items].filter((id) => !known.has(id));
+
+      for (const b of boxes()) b.checked = sel.items.has(b.value);
+      for (const b of subs()) {
+        b.checked = sel.lines.get(b.dataset.id)?.has(Number(b.dataset.line)) ?? false;
+      }
+      applyDetail();
+      recount();
+
+      const restored = sel.items.size - missing.length;
+      const parts = [`Loaded ${plural(restored, 'entry', 'entries')}.`];
+      // The commit is why the file carries one. If entries have gone missing,
+      // the fix is mechanical, so say what it is rather than only that it broke.
+      const from = sel.site.commit;
+      const here = SITE.commit;
+      if (missing.length) {
+        parts.push(`${plural(missing.length, 'entry', 'entries')} no longer ${missing.length === 1 ? 'exists' : 'exist'} here.`);
+        if (from && here && from !== here) {
+          parts.push(`Saved from ${sel.site.short ?? from.slice(0, 7)}; this site is ${SITE.short}.`);
+          parts.push(`git checkout ${from} && npm run build to recover ${missing.length === 1 ? 'it' : 'them'}.`);
+        } else {
+          parts.push('They were removed from the database.');
+        }
+      } else if (from && here && from !== here) {
+        parts.push(`Saved from ${sel.site.short ?? from.slice(0, 7)}; every entry still resolves.`);
+      }
+      if (sel.site.dirty) parts.push('That build had uncommitted changes.');
+      status(parts.join(' '));
+      if (missing.length) console.warn('Entries not present in this build:', missing);
+    };
+
+    const loadFile = async (file) => {
+      if (!file) return;
+      try {
+        applySelection(decode(await file.text()));
+      } catch (err) {
+        status(err?.message ?? 'That file could not be read.');
+      }
+    };
+
+    // Save lives in the condensed bar, which is where the controls are once you
+    // are actually working through the list.
+    document.addEventListener('click', (e) => {
+      if (e.target.closest('#savebar')) saveSelection();
+      if (e.target.closest('#load')) $('loadfile').click();
+    });
+    $('loadfile').addEventListener('change', (e) => {
+      loadFile(e.target.files?.[0]);
+      // Cleared so choosing the same file twice fires change again.
+      e.target.value = '';
     });
 
     // The compile controls are one element, not two: when the condensed header

--- a/tests/selection.test.js
+++ b/tests/selection.test.js
@@ -1,0 +1,91 @@
+// The saved-selection file. Its input is a file the user picked, so the cases
+// that matter most are the malformed ones: a wrong file chosen by accident has
+// to say so, not throw from inside the DOM code that called it.
+
+import { describe, expect, it } from 'vitest';
+import { encode, decode, SelectionError, FORMAT, VERSION } from '../src/lib/selection.js';
+
+const site = { commit: 'a'.repeat(40), short: 'aaaaaaa', dirty: false };
+
+describe('round trip', () => {
+  it('keeps the entries and their kept lines', () => {
+    const out = decode(JSON.stringify(encode({ items: ['x', 'y'], lines: { x: [0, 2] }, site })));
+    expect([...out.items]).toEqual(['x', 'y']);
+    expect([...out.lines.get('x')]).toEqual([0, 2]);
+  });
+
+  it('carries the commit, which is the point of the file', () => {
+    const out = decode(JSON.stringify(encode({ items: ['x'], lines: {}, site })));
+    expect(out.site.commit).toBe(site.commit);
+    expect(out.site.dirty).toBe(false);
+  });
+
+  it('records a dirty build, so a commit is not trusted to reproduce it', () => {
+    const out = decode(JSON.stringify(encode({ items: [], lines: {}, site: { ...site, dirty: true } })));
+    expect(out.site.dirty).toBe(true);
+  });
+
+  it('deduplicates and sorts, so the file is stable to diff', () => {
+    const e = encode({ items: ['b', 'a', 'b'], lines: { a: [3, 1, 1] }, site });
+    expect(e.items).toEqual(['b', 'a']);
+    expect(e.lines.a).toEqual([1, 3]);
+  });
+
+  it('drops entries whose lines are all unticked rather than writing empties', () => {
+    expect(encode({ items: ['a'], lines: { a: [] }, site }).lines).toEqual({});
+  });
+});
+
+describe('rejecting the wrong file', () => {
+  const bad = (text, match) => {
+    expect(() => decode(text)).toThrow(SelectionError);
+    expect(() => decode(text)).toThrow(match);
+  };
+
+  it('refuses something that is not JSON', () => bad('not json at all', /not JSON/));
+  it('refuses JSON that is not an object', () => bad('[1,2,3]', /not a saved selection/));
+  it('refuses null', () => bad('null', /not a saved selection/));
+  it('refuses another tool\'s JSON', () => bad('{"hello":"world"}', /not a CV selection file/));
+
+  it('refuses a file from a newer version rather than half-honouring it', () => {
+    bad(JSON.stringify({ format: FORMAT, version: VERSION + 1, items: [] }), /newer version/);
+  });
+
+  it('refuses a file with no entry list', () => {
+    bad(JSON.stringify({ format: FORMAT, version: 1 }), /no entry list/);
+  });
+
+  it('refuses an implausibly large list rather than expanding it', () => {
+    const items = Array.from({ length: 5001 }, (_, i) => `i${i}`);
+    bad(JSON.stringify({ format: FORMAT, version: 1, items }), /implausibly large/);
+  });
+
+  it('refuses a malformed detail list', () => {
+    bad(JSON.stringify({ format: FORMAT, version: 1, items: [], lines: [] }), /malformed detail list/);
+  });
+});
+
+describe('tolerating the merely odd', () => {
+  const read = (o) => decode(JSON.stringify({ format: FORMAT, version: 1, items: [], ...o }));
+
+  it('accepts a file with no lines at all', () => {
+    expect(read({}).lines.size).toBe(0);
+  });
+
+  it('skips non-string ids and non-integer line numbers', () => {
+    const out = decode(JSON.stringify({
+      format: FORMAT, version: 1, items: ['ok', 7, null], lines: { a: [0, 'x', -1, 2.5, 3] },
+    }));
+    expect([...out.items]).toEqual(['ok']);
+    expect([...out.lines.get('a')]).toEqual([0, 3]);
+  });
+
+  it('survives a missing or malformed site block', () => {
+    expect(read({ site: 'nope' }).site.commit).toBeNull();
+    expect(read({}).site.commit).toBeNull();
+  });
+
+  it('ignores fields it does not know', () => {
+    expect(read({ somethingNew: { a: 1 } }).items.size).toBe(0);
+  });
+});


### PR DESCRIPTION
A custom CV is a list of ticks over 176 entries, and it was one reload from gone. **Save** writes the selection to a JSON file; **Load** reads one back.

## The commit is the point

A selection is a list of ids, and ids only mean something against a version of the database. Entries get added, re-worded and removed — so a selection kept for a few months will name things that no longer exist.

The file records the commit the site was built from, and on load the page says what it could not restore:

```
Loaded 1 entry. 1 entry no longer exists here. Saved from 1111111; this site
is bf9669b. git checkout 1111…1111 && npm run build to recover it.
```

That is the whole feature — silently restoring a shorter CV would be the bad outcome. A build with uncommitted changes is recorded as `dirty`, because its commit alone will not reproduce it, and saying so beats implying recoverability that isn't there.

## The file

```json
{
  "format": "starkman-cv-selection",
  "version": 1,
  "savedAt": "2026-08-25T…",
  "site": { "commit": "bf9669b…", "short": "bf9669b", "dirty": false },
  "items": ["toronto-phd", "cwru-bs", "mit-postdoc"],
  "lines": { "toronto-phd": [0, 2] }
}
```

Written indented and with sorted, de-duplicated ids — it is small, and a selection you can read and hand-edit is worth more than the saved bytes. Saved as `starkman-cv-<short>.json`.

## Input validation

`decode()` treats its input as hostile: it is a file the user picked, and the common failure is picking the wrong one. Each case fails with a sentence, not a `TypeError` three frames down in the DOM code:

```
That file is not JSON.
That is not a CV selection file.
That selection was saved by a newer version of this page (v99).
That selection has no entry list.
That selection has a malformed detail list.
That selection is implausibly large.
```

Unknown fields are ignored, non-string ids and non-integer line numbers are skipped, and a missing `site` block is tolerated. **17 new unit tests** cover the round trip and every rejection above (87 total, up from 70).

## The three UI changes

1. **The condensed bar drops the length toggle on the builder.** Beyond making room, jumping to a fixed length mid-build would have discarded the selection with no warning. The lengths stay in the heading row, so leaving the builder is something you scroll up to do deliberately.
2. **Save takes that slot** — the right-hand side, where the controls already are once you're working down the list.
3. **Load joins `Start from`**, which is where a selection begins. The `·` before *None* is gone and a `|` sits between *None* and *Load*:

```
START FROM  [Complete] [NP] [2P] [1P] [None] | [Load]        96 / 176
```

## Verified in the browser

- **Save** → intercepted the blob: correct format, `site` block, 3 items, 66 line entries, filename `starkman-cv-bf9669b.json`.
- **Load** → scrambled to all 176 ticked, fed the file back, got exactly the 3 entries and 72 sub-lines returned, count `3 / 176`.
- **Stale commit** → the recovery message above, with the full SHA.
- **Bar contents** → `Compile PDF · Download · Save | Build`, no presets; heading row still has all four lengths.
- **Geometry** → Compile PDF at x=24, Save at x=413–462 in a 562px bar: right-hand side, exactly the presets' old slot.
- **Focus guard** → `tabIndex` is `-1` on Save and Build while the bar is hidden, `0` when shown. The guard now covers `button` as well as `a`, which it had to once the bar contained a button.
- `/cv/` is unaffected: its bar still carries all four lengths and neither Save nor Load leaks onto it.

Build ok, 87 unit tests, schema, bibtex, a11y across 9 pages, page contracts (1P one page, 2P two), 776 links. Link count is down 4 from 780 — those are the four preset links removed from the builder's bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)