### PR TITLE
Name the bibliography nstarkman_publications.bib

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ database, and the tooling that renders one into the other.
 
 Everything comes out of `data/`. One JSON file per item, and the same database
 renders the website, the [profile README][profile], the CV PDFs, and
-[publications.bib](https://nstarkman.space/publications.bib). Adding a paper or
+[nstarkman_publications.bib](https://nstarkman.space/nstarkman_publications.bib). Adding a paper or
 a conference is one small file.
 
 **Adding something? Read [AGENTS.md](AGENTS.md).**

--- a/src/pages/nstarkman_publications.bib.js
+++ b/src/pages/nstarkman_publications.bib.js
@@ -1,8 +1,10 @@
 import { items } from '../lib/data.js';
 import { toBibliography } from '../lib/bibtex.js';
 
-// Served at /publications.bib so the .bib is a first-class artefact of the
-// database rather than something exported by hand.
+// Served at /nstarkman_publications.bib so the .bib is a first-class artefact
+// of the database rather than something exported by hand. Named rather than
+// generic because it is downloaded into other people's reference managers and
+// BibTeX directories, where a file called publications.bib is one of several.
 export function GET() {
   // Matches /publications/, which this is linked from: in-preparation papers
   // have no citable form, so they are not in the bibliography either.

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -21,7 +21,7 @@ const all = byType('publication').filter((p) => p.status !== 'in-prep');
         <div class="h2row">
           <h2>Publications</h2>
           <span class="more pubprofiles">
-            <a href="/publications.bib">BibTeX</a>
+            <a href="/nstarkman_publications.bib">BibTeX</a>
             <span class="sep">|</span>
             {profiles.map((c) => (
               <a class="pill" href={c.url} aria-label={c.label} title={`All publications on ${c.label}`}>


### PR DESCRIPTION
`Publications | BibTeX` now serves `/nstarkman_publications.bib`.

The file gets downloaded into other people's BibTeX directories and reference managers, where `publications.bib` is one of several and says nothing about whose it is.

## Why rename the route rather than add `download="…"`

A `download` attribute would fix the click, but not Save As from the address bar or a direct fetch of the URL — both take the name from the path. Renaming makes the URL and the saved file agree however it is reached.

The old path had no references outside this repo (checked the profile repo too) and is only hours old, so it goes rather than earning an alias — unlike `/files/starkman_cv.pdf`, which is kept because the Jekyll site served it for years.

Updated: the link on `/publications/`, the route's own comment, and the `README.md` link.

Verified the artefact is unchanged apart from its name — 17 entries, still valid BibTeX, `dist/publications.bib` gone. bibtex, links (776), a11y and 87 unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)