### PR TITLE
Add ORCIDs to 35 of 36 co-author bylines

### DIFF
--- a/data/2018-02-maximum-discs.json
+++ b/data/2018-02-maximum-discs.json
@@ -20,15 +20,18 @@
     },
     {
       "family": "Lelli",
-      "given": "F."
+      "given": "F.",
+      "orcid": "0000-0002-9024-9883"
     },
     {
       "family": "McGaugh",
-      "given": "S. S."
+      "given": "S. S.",
+      "orcid": "0000-0002-9762-0980"
     },
     {
       "family": "Schombert",
-      "given": "J."
+      "given": "J.",
+      "orcid": "0000-0003-2022-1911"
     }
   ],
   "venue": {

--- a/data/2018-11-sparc-halo-density.json
+++ b/data/2018-11-sparc-halo-density.json
@@ -14,15 +14,18 @@
   "authors": [
     {
       "family": "Li",
-      "given": "P."
+      "given": "P.",
+      "orcid": "0000-0002-6707-2581"
     },
     {
       "family": "Lelli",
-      "given": "F."
+      "given": "F.",
+      "orcid": "0000-0002-9024-9883"
     },
     {
       "family": "McGaugh",
-      "given": "S. S."
+      "given": "S. S.",
+      "orcid": "0000-0002-9762-0980"
     },
     {
       "family": "Starkman",
@@ -32,7 +35,8 @@
     },
     {
       "family": "Schombert",
-      "given": "J. M."
+      "given": "J. M.",
+      "orcid": "0000-0003-2022-1911"
     }
   ],
   "venue": {

--- a/data/2020-06-macro-lightning.json
+++ b/data/2020-06-macro-lightning.json
@@ -26,7 +26,8 @@
     },
     {
       "family": "Winch",
-      "given": "Harrison"
+      "given": "Harrison",
+      "orcid": "0000-0002-0092-6271"
     },
     {
       "family": "Starkman",

--- a/data/2020-06-macro-lightning.json
+++ b/data/2020-06-macro-lightning.json
@@ -21,7 +21,8 @@
     },
     {
       "family": "Sidhu",
-      "given": "Jagjit Singh"
+      "given": "Jagjit Singh",
+      "orcid": "0000-0002-1956-1305"
     },
     {
       "family": "Winch",
@@ -29,7 +30,8 @@
     },
     {
       "family": "Starkman",
-      "given": "Glenn"
+      "given": "Glenn",
+      "orcid": "0000-0002-5053-1542"
     }
   ],
   "venue": {

--- a/data/2020-pal5-gaia-dr2.json
+++ b/data/2020-pal5-gaia-dr2.json
@@ -26,7 +26,8 @@
     },
     {
       "family": "Webb",
-      "given": "Jeremy"
+      "given": "Jeremy",
+      "orcid": "0000-0003-3613-0854"
     }
   ],
   "venue": {

--- a/data/2020-pal5-gaia-dr2.json
+++ b/data/2020-pal5-gaia-dr2.json
@@ -21,7 +21,8 @@
     },
     {
       "family": "Bovy",
-      "given": "Jo"
+      "given": "Jo",
+      "orcid": "0000-0001-6855-442X"
     },
     {
       "family": "Webb",

--- a/data/2022-08-astropy-v5-paper.json
+++ b/data/2022-08-astropy-v5-paper.json
@@ -16,15 +16,18 @@
   "authors": [
     {
       "family": "Price-Whelan",
-      "given": "Adrian M."
+      "given": "Adrian M.",
+      "orcid": "0000-0003-0872-7098"
     },
     {
       "family": "Lim",
-      "given": "Pey Lian"
+      "given": "Pey Lian",
+      "orcid": "0000-0003-0079-4114"
     },
     {
       "family": "Earl",
-      "given": "Nicholas"
+      "given": "Nicholas",
+      "orcid": "0000-0003-1714-7415"
     },
     {
       "family": "Starkman",

--- a/data/2023-04-characterizing-stream-tracks.json
+++ b/data/2023-04-characterizing-stream-tracks.json
@@ -22,7 +22,8 @@
     },
     {
       "family": "Bovy",
-      "given": "Jo"
+      "given": "Jo",
+      "orcid": "0000-0001-6855-442X"
     },
     {
       "family": "Webb",
@@ -30,11 +31,13 @@
     },
     {
       "family": "Calvetti",
-      "given": "Daniela"
+      "given": "Daniela",
+      "orcid": "0000-0001-5696-718X"
     },
     {
       "family": "Somersalo",
-      "given": "Erkki"
+      "given": "Erkki",
+      "orcid": "0000-0001-5099-3512"
     }
   ],
   "venue": {

--- a/data/2023-04-characterizing-stream-tracks.json
+++ b/data/2023-04-characterizing-stream-tracks.json
@@ -27,7 +27,8 @@
     },
     {
       "family": "Webb",
-      "given": "Jeremy"
+      "given": "Jeremy",
+      "orcid": "0000-0003-3613-0854"
     },
     {
       "family": "Calvetti",

--- a/data/2023-cosmology-api.json
+++ b/data/2023-cosmology-api.json
@@ -21,7 +21,8 @@
     },
     {
       "family": "Tessore",
-      "given": "Nicolas"
+      "given": "Nicolas",
+      "orcid": "0000-0002-9696-7931"
     }
   ],
   "links": [

--- a/data/2024-03-cmb-spectrum-distortions.json
+++ b/data/2024-03-cmb-spectrum-distortions.json
@@ -22,11 +22,13 @@
     },
     {
       "family": "Kosowsky",
-      "given": "Arthur"
+      "given": "Arthur",
+      "orcid": "0000-0002-3734-331X"
     },
     {
       "family": "Starkman",
-      "given": "Glenn"
+      "given": "Glenn",
+      "orcid": "0000-0002-5053-1542"
     }
   ],
   "venue": {

--- a/data/2024-03-galax.json
+++ b/data/2024-03-galax.json
@@ -27,11 +27,13 @@
     },
     {
       "family": "Price-Whelan",
-      "given": "Adrian"
+      "given": "Adrian",
+      "orcid": "0000-0003-0872-7098"
     },
     {
       "family": "Nibauer",
-      "given": "Jacob"
+      "given": "Jacob",
+      "orcid": "0000-0001-8042-5794"
     }
   ],
   "links": [

--- a/data/2025-01-stream-members-only.json
+++ b/data/2025-01-stream-members-only.json
@@ -23,11 +23,13 @@
     },
     {
       "family": "Nibauer",
-      "given": "Jacob"
+      "given": "Jacob",
+      "orcid": "0000-0001-8042-5794"
     },
     {
       "family": "Bovy",
-      "given": "Jo"
+      "given": "Jo",
+      "orcid": "0000-0001-6855-442X"
     },
     {
       "family": "Webb",
@@ -35,11 +37,13 @@
     },
     {
       "family": "Tavangar",
-      "given": "Kiyan"
+      "given": "Kiyan",
+      "orcid": "0000-0001-6584-6144"
     },
     {
       "family": "Price-Whelan",
-      "given": "Adrian"
+      "given": "Adrian",
+      "orcid": "0000-0003-0872-7098"
     },
     {
       "family": "Bonaca",

--- a/data/2025-01-stream-members-only.json
+++ b/data/2025-01-stream-members-only.json
@@ -33,7 +33,8 @@
     },
     {
       "family": "Webb",
-      "given": "Jeremy"
+      "given": "Jeremy",
+      "orcid": "0000-0003-3613-0854"
     },
     {
       "family": "Tavangar",
@@ -47,7 +48,8 @@
     },
     {
       "family": "Bonaca",
-      "given": "Ana"
+      "given": "Ana",
+      "orcid": "0000-0002-7846-9787"
     }
   ],
   "venue": {

--- a/data/2025-12-pinns-neurips.json
+++ b/data/2025-12-pinns-neurips.json
@@ -14,7 +14,8 @@
   "authors": [
     {
       "family": "Myers",
-      "given": "Charlotte"
+      "given": "Charlotte",
+      "orcid": "0009-0005-9329-8196"
     },
     {
       "family": "Starkman",
@@ -24,7 +25,8 @@
     },
     {
       "family": "Necib",
-      "given": "Lina"
+      "given": "Lina",
+      "orcid": "0000-0003-2806-1414"
     }
   ],
   "venue": {

--- a/data/2025-streamsculptor.json
+++ b/data/2025-streamsculptor.json
@@ -15,7 +15,8 @@
   "authors": [
     {
       "family": "Nibauer",
-      "given": "Jacob"
+      "given": "Jacob",
+      "orcid": "0000-0001-8042-5794"
     },
     {
       "family": "Starkman",

--- a/data/2025-streamsculptor.json
+++ b/data/2025-streamsculptor.json
@@ -26,7 +26,8 @@
     },
     {
       "family": "Johnston",
-      "given": "K."
+      "given": "K.",
+      "orcid": "0000-0001-6244-6727"
     }
   ],
   "venue": {

--- a/data/2026-05-galactic-amnesia.json
+++ b/data/2026-05-galactic-amnesia.json
@@ -20,11 +20,13 @@
     },
     {
       "family": "Folsom",
-      "given": "Dylan"
+      "given": "Dylan",
+      "orcid": "0000-0002-1544-1381"
     },
     {
       "family": "Davies",
-      "given": "Elliot Y."
+      "given": "Elliot Y.",
+      "orcid": "0000-0001-5996-4072"
     },
     {
       "family": "Starkman",
@@ -34,7 +36,8 @@
     },
     {
       "family": "Thoyas",
-      "given": "Andreas"
+      "given": "Andreas",
+      "orcid": "0009-0005-1250-1800"
     }
   ],
   "abstract": "The merger history of a galaxy leaves imprints on its present-day stellar chemodynamics, yet dynamical processes progressively erase this record. We ask: how far back in time, and from which observables, can a galaxy's assembly history still be recovered? We provide a quantitative framework to address this question, using Mutual Information normalized by Shannon entropy to measure how much present-day stellar chemodynamics retains about each past merger's stellar mass $M_\\star$ and infall time $t_{\\rm infall}$. This framework is applied to TNG50 Milky Way -- like galaxies, with comparison to FIRE-2. We find that the gravitational potential and total energy are the most informative and longest-lived tracers of merger properties, highlighting the need for accurately measuring the Milky Way's potential. The information carried by the radial velocity decays to the noise floor within $\\sim$5 Gyr, angular momentum carries low information overall with a mass-dependent decay, and chemical abundances retain a flat, low information floor. Information washout depends on three key factors: (1) radial position -- stars in the inner galaxy lose information faster due to shorter orbital times; (2) infall time -- old mergers are largely phase-mixed; and (3) merger mass -- larger mergers sink to the bottom of the potential well via dynamical friction, inducing violent relaxation that erases dynamical information. At each galactocentric radius, we map the observational horizon in the $(M_\\star,\\; t_{\\rm infall})$ plane beyond which past mergers can no longer be recovered from that observable. By recasting merger reconstruction into this quantitative, observable-by-observable map of what is and is not recoverable, our results provide a foundation for interpreting chemodynamical signatures of past mergers and for guiding surveys and modeling toward the observables that maximize merger information recovery.",

--- a/data/2026-05-galactic-amnesia.json
+++ b/data/2026-05-galactic-amnesia.json
@@ -16,7 +16,8 @@
   "authors": [
     {
       "family": "Necib",
-      "given": "Lina"
+      "given": "Lina",
+      "orcid": "0000-0003-2806-1414"
     },
     {
       "family": "Folsom",

--- a/data/2026-05-potamides-apj.json
+++ b/data/2026-05-potamides-apj.json
@@ -16,7 +16,8 @@
   "authors": [
     {
       "family": "Wu",
-      "given": "Sirui"
+      "given": "Sirui",
+      "orcid": "0009-0003-4675-3622"
     },
     {
       "family": "Starkman",
@@ -26,11 +27,13 @@
     },
     {
       "family": "Pearson",
-      "given": "Sarah"
+      "given": "Sarah",
+      "orcid": "0000-0003-0256-5446"
     },
     {
       "family": "Nibauer",
-      "given": "Jacob"
+      "given": "Jacob",
+      "orcid": "0000-0001-8042-5794"
     },
     {
       "family": "Miro-Carretero",

--- a/data/2026-05-potamides-apj.json
+++ b/data/2026-05-potamides-apj.json
@@ -37,11 +37,13 @@
     },
     {
       "family": "Miro-Carretero",
-      "given": "Juan"
+      "given": "Juan",
+      "orcid": "0000-0003-1808-1753"
     },
     {
       "family": "Martinez-Delgado",
-      "given": "David"
+      "given": "David",
+      "orcid": "0009-0004-1061-7802"
     }
   ],
   "venue": {

--- a/data/2026-06-euclid-eggs-pilot.json
+++ b/data/2026-06-euclid-eggs-pilot.json
@@ -24,15 +24,18 @@
     },
     {
       "family": "Nibauer",
-      "given": "Jacob"
+      "given": "Jacob",
+      "orcid": "0000-0001-8042-5794"
     },
     {
       "family": "Pearson",
-      "given": "S."
+      "given": "S.",
+      "orcid": "0000-0003-0256-5446"
     },
     {
       "family": "Wu",
-      "given": "Sirui"
+      "given": "Sirui",
+      "orcid": "0009-0003-4675-3622"
     },
     {
       "family": "Walmsley",
@@ -44,7 +47,8 @@
     },
     {
       "family": "Bovy",
-      "given": "Jo"
+      "given": "Jo",
+      "orcid": "0000-0001-6855-442X"
     },
     {
       "family": "Marleau",

--- a/data/2026-06-euclid-eggs-pilot.json
+++ b/data/2026-06-euclid-eggs-pilot.json
@@ -39,11 +39,13 @@
     },
     {
       "family": "Walmsley",
-      "given": "M."
+      "given": "M.",
+      "orcid": "0000-0002-6408-4181"
     },
     {
       "family": "Necib",
-      "given": "Lina"
+      "given": "Lina",
+      "orcid": "0000-0003-2806-1414"
     },
     {
       "family": "Bovy",
@@ -52,11 +54,13 @@
     },
     {
       "family": "Marleau",
-      "given": "F. R."
+      "given": "F. R.",
+      "orcid": "0000-0002-1442-2947"
     },
     {
       "family": "Sola",
-      "given": "E."
+      "given": "E.",
+      "orcid": "0000-0002-2814-3578"
     },
     {
       "family": "Scott",

--- a/data/2026-06-pinns-mnras.json
+++ b/data/2026-06-pinns-mnras.json
@@ -17,7 +17,8 @@
   "authors": [
     {
       "family": "Myers",
-      "given": "Charlotte"
+      "given": "Charlotte",
+      "orcid": "0009-0005-9329-8196"
     },
     {
       "family": "Starkman",
@@ -27,7 +28,8 @@
     },
     {
       "family": "Necib",
-      "given": "Lina"
+      "given": "Lina",
+      "orcid": "0000-0003-2806-1414"
     }
   ],
   "venue": {

--- a/data/2026-coordinax-paper.json
+++ b/data/2026-coordinax-paper.json
@@ -18,7 +18,8 @@
     },
     {
       "family": "Price-Whelan",
-      "given": "Adrian"
+      "given": "Adrian",
+      "orcid": "0000-0003-0872-7098"
     }
   ],
   "refs": [


### PR DESCRIPTION
Data only — no rendering change, so the identifiers can be checked before anything links to them.

**35 of 36 bylines** now carry an ORCID. Only `D. Scott` on the Euclid paper is still without.

## Provenance

| how | count |
|---|---|
| Confirmed — their ORCID record claims a paper you co-authored | 21 |
| Supplied by you | 12 |
| Already in the data, verified to resolve | 2 |

For the first group I asked ORCID **who claims this DOI** rather than matching names, so a match means that person's own record lists a paper you're both on. Your own ORCID came back on the Astropy query, which is the method checking itself. Where a paper had no journal DOI I tried `10.48550/arXiv.…`, then checked candidates' work lists for a shared title.

Every ORCID you supplied was checked against ORCID before being written, and each resolves to a person whose surname matches the byline — Elisabeth Sola, Kathryn Johnston (Columbia), Mike Walmsley (Manchester/Oxford), Francine Marleau (Innsbruck), Jeremy Webb (Toronto), David Martinez-Delgado (CEFCA).

## Leaving the doubtful ones blank was the right call

**Jeremy Webb's actual ORCID is not one of the four candidates a name search returned.** Any of them would have been wrong — and wrong in a way that looks right, because all four are genuinely called Jeremy Webb. Same shape of risk for `K. Johnston` (2312 name hits) and `M. Walmsley` (137).

## Both spellings, one ORCID

You confirmed these are the same people. They share an ORCID but **keep their own bylines**:

| | |
|---|---|
| `Adrian M. Price-Whelan` / `Adrian Price-Whelan` | `0000-0003-0872-7098` |
| `J. Schombert` / `J. M. Schombert` | `0000-0003-2022-1911` |
| `S. Pearson` / `Sarah Pearson` | `0000-0003-0256-5446` |

I did not normalise to one spelling: a byline has to keep matching the paper it appears on, and rewriting `S. Pearson` to `Sarah Pearson` would make our BibTeX disagree with what Euclid published. One ORCID on both forms fixes the inconsistent-links problem without falsifying a citation.

## No website field

Per your call — the ORCID is the link target, so a second URL per person would be one more thing to keep current, and it would have needed a schema change (the author object is `additionalProperties: false`).

## Verified

Schema passes; the `orcid` pattern was already in the author schema, so no schema change at all. BibTeX output is byte-identical — `orcid` appears 0 times in the `.bib`, as it should. 87 unit tests, 776 links, a11y across 9 pages.

Next, separately: rendering the bylines as links to these ORCIDs, on the site and in the CV PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)