### PR TITLE
Link co-author names to their ORCID on the website

### DIFF
--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -159,7 +159,11 @@ const money = (a) => {
             {item.event && <>, {item.event}</>}
             {item.type === 'publication' && (
               <> — {authors(item, 4).shown.map((a, i) => (
-                  <>{i > 0 && ', '}{a.me ? <span class="me">{a.name}</span> : a.name}</>
+                  <>{i > 0 && ', '}{a.me
+                    ? <span class="me">{a.name}</span>
+                    : a.url
+                      ? <a class="authorlink" href={a.url}>{a.name}</a>
+                      : a.name}</>
                 ))}{authors(item, 4).etal && <>, et al</>}
                 {(authors(item, 4).etal || venueLine(item)) && '.'}
                 {venueLine(item) && <> <span class="venue">{venueLine(item)}</span></>}

--- a/src/components/Publication.astro
+++ b/src/components/Publication.astro
@@ -23,7 +23,11 @@ const pending = item.status !== 'published' ? item.status : null;
     <p class="meta">
       {collaboration && <>{collaboration}, </>}
       {shown.map((a, i) => (
-        <>{i > 0 && ', '}{a.me ? <span class="me">{a.name}</span> : a.name}</>
+        <>{i > 0 && ', '}{a.me
+          ? <span class="me">{a.name}</span>
+          : a.url
+            ? <a class="authorlink" href={a.url}>{a.name}</a>
+            : a.name}</>
       ))}
       {etal && <>, et al.</>}
       {brief && venue && <> · <span class="venue">{venue}</span></>}

--- a/src/lib/cvmodel.js
+++ b/src/lib/cvmodel.js
@@ -86,7 +86,12 @@ function paperOf(sw) {
   return null;
 }
 
-/** The byline, with the CV's owner bold. */
+/** The byline, with the CV's owner bold.
+ *
+ * Deliberately carries no ORCID link. The author model has one, but the PDF is
+ * the only consumer of this byline and it stays unlinked — so the span never
+ * gets a `url` key that cv.typ would have to decide what to do with.
+ */
 function byline(item) {
   const { shown, etal, collaboration } = authors(item, 6);
   const out = [];

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -67,13 +67,24 @@ export function displayName(a) {
   return [initials(a.given), a.family, a.suffix].filter(Boolean).join(' ');
 }
 
+/** Where a co-author's name points. ORCID is the identifier, so it is the link. */
+export const orcidUrl = (orcid) => (orcid ? `https://orcid.org/${orcid}` : null);
+
 /**
  * Authors for display, truncated per preset. The data always holds the full
  * list — truncating there would corrupt the BibTeX — so it happens here.
+ *
+ * `url` is the author's ORCID page, and is null for the owner: this is his own
+ * site, his ORCID is already in the CV header, and a self-link in every byline
+ * would be noise rather than navigation.
  */
 export function authors(item, max = Infinity) {
   const all = item.authors ?? [];
-  const shown = all.slice(0, max).map((a) => ({ name: displayName(a), me: Boolean(a.me) }));
+  const shown = all.slice(0, max).map((a) => ({
+    name: displayName(a),
+    me: Boolean(a.me),
+    url: a.me ? null : orcidUrl(a.orcid),
+  }));
   return { shown, etal: all.length > max, collaboration: item.collaboration };
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -410,6 +410,12 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
   .cvtoc a.is-current{color:var(--ink); border-color:var(--accent); font-weight:500}
 }
 .tl .recipient{color:var(--ink-mute); font-style:italic}
+
+/* A co-author's name links to their ORCID. Eight accent-coloured names in a row
+   would turn a byline into a wall of links, so it reads as text and only shows
+   itself on hover and focus. */
+.authorlink{color:inherit; text-decoration:none; border-bottom:1px solid transparent}
+.authorlink:hover, .authorlink:focus-visible{color:var(--accent); border-bottom-color:var(--accent-line)}
 .tl{scroll-margin-top:5rem}
 
 

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -86,6 +86,24 @@ describe('authors', () => {
     expect(authors(paper, 2).etal).toBe(true);
     expect(authors(paper, 9).etal).toBe(false);
   });
+
+  it('points a co-author at their ORCID', () => {
+    // Jo Bovy, whose ORCID was confirmed from his own claim on this paper.
+    const bovy = authors(resolve('pal5-gaia-dr2')).shown.find((a) => a.name.endsWith('Bovy'));
+    expect(bovy.url).toBe('https://orcid.org/0000-0001-6855-442X');
+  });
+
+  it('does not self-link the owner', () => {
+    // His ORCID is in the CV header; a self-link in every byline is noise.
+    const me = authors(resolve('pal5-gaia-dr2')).shown.find((a) => a.me);
+    expect(me.url).toBeNull();
+  });
+
+  it('leaves a co-author with no ORCID unlinked rather than guessing', () => {
+    // D. Scott on the Euclid paper: initials too common to identify.
+    const scott = authors(resolve('euclid-eggs-pilot'), 20).shown.find((a) => a.name.endsWith('Scott'));
+    expect(scott.url).toBeNull();
+  });
 });
 
 describe('venueLine', () => {


### PR DESCRIPTION
Follow-up to #24, now that the identifiers are on `main`. Rendering only — no data files touched.

## What links

| page | author links |
|---|---|
| `/publications/` | 53 |
| `/cv/` | 41 |
| `/` | 8 |

`authors()` in `lib/data.js` now carries each co-author's ORCID page, and the two components that render bylines make the name a link.

## Three deliberate omissions

**The owner is not self-linked.** This is his own site and his ORCID is already in the CV header — a self-link in every byline is noise rather than navigation.

**A co-author without an ORCID stays plain text.** That is only `D. Scott` on the Euclid paper today, but the rule matters: no guessed links.

**Nothing in the PDF**, per your instruction. The byline the model hands to `cv.typ` therefore carries no `url` key at all, rather than one the template has to know to ignore — so `cv.typ` is untouched by this PR. The single ORCID link in the PDF is your own in the header, which was already there:

```
ORCID links in the PDF: 1 ['https://orcid.org/0000-0003-3954-3291']
```

## Styling

Author names read as text and reveal themselves on hover and focus:

```css
.authorlink{color:inherit; text-decoration:none; border-bottom:1px solid transparent}
.authorlink:hover, .authorlink:focus-visible{color:var(--accent); border-bottom-color:var(--accent-line)}
```

Eight accent-coloured names in a row would turn a byline into a wall of links. The class is `.authorlink` rather than `.who`, which is already taken by the nav's site name.

## Verified

Three new unit tests (90 total): a co-author points at their ORCID, the owner's `url` is null, and an unidentified co-author stays unlinked.

Spot-checked six generated URLs against orcid.org — all 200. Worth doing, because `test-links.mjs` only resolves internal links, so a malformed external URL would otherwise ship unnoticed.

Links (776), a11y across 9 pages, schema, bibtex, and the page-count contracts all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)