### PR TITLE
Centre the page title against its controls, not the baseline

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,7 +94,13 @@ h2{
   font-family:var(--serif); font-weight:500; font-size:1.28rem; margin:0 0 .95rem;
   letter-spacing:-.01em;
 }
-.h2row{display:flex; align-items:baseline; justify-content:space-between; gap:1rem; margin-bottom:.95rem}
+/* Centred, not baseline. The right-hand side is a cluster of controls — pills,
+   a segmented filter, a bare glyph — with no single text baseline, so baseline
+   alignment resolved against whichever child happened to come first and left
+   the title sitting a different amount off on every page: 0.2px on the CV,
+   0.56px on the home page, 0.82px on Publications. Centring the boxes is
+   independent of what the row contains. */
+.h2row{display:flex; align-items:center; justify-content:space-between; gap:1rem; margin-bottom:.95rem}
 .h2row h2{margin:0}
 .more{font-family:var(--mono); font-size:.72rem; letter-spacing:.06em; text-transform:uppercase}
 


### PR DESCRIPTION
`.h2row` aligned the page title against its controls with `align-items: baseline`. The right-hand side is a cluster with no single text baseline between its parts — a mono label, a segmented filter, a `|`, two circular pills, a bare glyph — so baseline alignment resolved against whichever child came first, and the title ended up a **different amount off on every page**:

```
/cv/            0.20px
/               0.56px
/publications/  0.82px
```

Small individually, but it is inconsistency rather than a constant offset, and it moves again every time a control is added to a row — which is exactly what just happened to Publications.

Centring the boxes does not depend on what the row holds:

```
/               Selected publications   0
                Software                0
/publications/  Publications            0
/cv/            Curriculum Vitae        0
/cv/builder/    Curriculum Vitae        0
```

On Publications I measured every part of the cluster against the title's centre, not just the container:

```
poslabel 0 · pubfilter 0 · sep 0 · pill 0 · baremark 0
```

This is the same rule `nav .wrap` already uses, so the title row and the nav row now agree rather than each doing their own thing.

Left edges and right edges were already correct and are unchanged — titles at the content's left edge, control clusters flush to its right edge, on every page and at every width I checked.

One-line change. 95 unit tests, 775 links, a11y across 9 pages.

> If what you were seeing was larger than a pixel, tell me what it was — this is what measurement found, and it is possible you spotted something else in that row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
