### PR TITLE
Sit the CV header on a faint wash

### DIFF
--- a/cv/assets/qr.svg
+++ b/cv/assets/qr.svg
@@ -2,7 +2,8 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 width="2291px" height="2291px" viewBox="0 0 2291 2291" enable-background="new 0 0 2291 2291" xml:space="preserve">
-<rect x="0" y="0" width="2291" height="2291" fill="rgb(255,255,255)" /><g transform="translate(158,158)"><g transform="translate(711,0) scale(0.79,0.79)"><g transform="" style="fill: rgb(0, 0, 0);">
+<!-- background removed so the header wash shows through; the dark modules
+     below are fill-less rects and render black as before --><g transform="translate(158,158)"><g transform="translate(711,0) scale(0.79,0.79)"><g transform="" style="fill: rgb(0, 0, 0);">
 <rect width="100" height="100"/>
 </g></g><g transform="translate(790,0) scale(0.79,0.79)"><g transform="" style="fill: rgb(0, 0, 0);">
 <rect width="100" height="100"/>

--- a/cv/cv.typ
+++ b/cv/cv.typ
@@ -28,6 +28,11 @@
 #let accent = rgb("#003399") // linkcolour: rgb(0, 0.2, 0.6)
 #let faint = rgb("#808080") // \grayhref: gray 0.5
 #let orcid = rgb("#A6CE39") // orcidlogocol
+// The header sits on this. Barely there by intent — enough to read as one
+// block rather than four columns that happen to be adjacent, not enough to
+// look like a filled panel, and light enough to survive an office printer
+// without banding.
+#let headerwash = luma(250)
 
 #set document(title: p.name + " — " + cv.label, author: p.name)
 // geometry scale=0.9 on A4, hmarginratio 1:1, vmarginratio 2:3
@@ -166,7 +171,10 @@
 // at both edges, and keeps agreeing if a title or an address line is added.
 #context {
   let h = measure(namecol).height
-  grid(
+  // `outset`, not `inset`: the wash is drawn around the grid without taking
+  // any space, so the header's geometry — and the page counts that depend on
+  // it — are exactly as they were.
+  block(fill: headerwash, radius: 8pt, outset: (x: 9pt, y: 8pt), grid(
     columns: (hdr, auto, 1fr, hdr),
     column-gutter: 11pt,
     align: (left + horizon, left + horizon, right + horizon, right + horizon),
@@ -185,7 +193,7 @@
     }),
 
     link(p.websiteUrl, image("assets/qr.svg", width: hdr)),
-  )
+  ))
 }
 
 // ── headings ──────────────────────────────────────────────────────────────

--- a/cv/cv.typ
+++ b/cv/cv.typ
@@ -173,8 +173,10 @@
   let h = measure(namecol).height
   // `outset`, not `inset`: the wash is drawn around the grid without taking
   // any space, so the header's geometry — and the page counts that depend on
-  // it — are exactly as they were.
-  block(fill: headerwash, radius: 8pt, outset: (x: 9pt, y: 8pt), grid(
+  // it — are exactly as they were. Tighter vertically than horizontally: the
+  // portrait and the QR already sit at the block's full height, so the same
+  // gap top and bottom as at the sides reads as a margin rather than a hug.
+  block(fill: headerwash, radius: 8pt, outset: (x: 9pt, y: 5pt), grid(
     columns: (hdr, auto, 1fr, hdr),
     column-gutter: 11pt,
     align: (left + horizon, left + horizon, right + horizon, right + horizon),


### PR DESCRIPTION
A very light rounded fill behind the CV header, so it reads as one unit rather than four columns that happen to be adjacent.

```typst
#let headerwash = luma(250)
block(fill: headerwash, radius: 8pt, outset: (x: 9pt, y: 8pt), grid(…))
```

`outset`, not `inset` — the fill is drawn *around* the grid without taking any space, so the header's geometry is untouched and the page-count contracts hold. Measured the text extents before and after: `LEFT 219..467 / RIGHT 221..471`, identical.

## The QR needed changing too

It carried an opaque white background, which was invisible on white paper but showed as a bright panel the moment there was anything behind it. Removed — the dark modules are fill-less `<rect>`s and render black exactly as before. One rect gone of 238; no white fills remain.

**It still scans.** I decoded both versions out of the rendered PDF rather than assuming:

```
BEFORE (white bg)      decoded: 'https://nstarkman.space'
AFTER (transparent)    decoded: 'https://nstarkman.space'
```

Black on `luma(250)` is about 19:1, so contrast was never in question, but the code is functional and worth checking rather than reasoning about.

## On the shade

`luma(250)` is my read of "so subtle you almost don't see it" while still surviving an office printer. I rendered 251, 249 and 246 side by side — say the word and it is a one-character change. 246 is clearly a panel; 251 is very nearly invisible on screen and likely to vanish in print.

Page contracts hold (1P one page, 2P two), six embedded fonts unchanged, 103 unit tests, 775 links, a11y across 9 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
