### PR TITLE
Flag unpublished papers on the CV page too

### DIFF
--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -155,6 +155,12 @@ const money = (a) => {
           </span>
           <span class="what">
             <strong>{item.title}</strong>
+            {/* The same pill the publications page uses. The CV page does not
+                group by status the way the PDF does, so without it a submitted
+                paper is indistinguishable from a published one. */}
+            {item.status && item.status !== 'published' && (
+              <span class="statustag">{item.status}</span>
+            )}
             {item.institution && <>, {item.institution}</>}
             {item.event && <>, {item.event}</>}
             {item.type === 'publication' && (

--- a/src/components/Publication.astro
+++ b/src/components/Publication.astro
@@ -21,7 +21,7 @@ const pos = authorPosition(item);
   <div class="body">
     <div class="ttl">
       <a href={paper?.url ?? '#'}>{item.title}</a>
-      {pending && <span class="status">{pending}</span>}
+      {pending && <span class="statustag">{pending}</span>}
     </div>
 
     <p class="meta">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,7 +117,11 @@ h2{
 .entry .meta{grid-column:1/-1; margin:0; font-size:.9rem; color:var(--ink-mute)}
 .entry .meta .me{color:var(--ink-2); font-weight:500}
 .entry .venue{font-style:italic}
-.status{
+/* The publication status pill. Named apart from .status, which is the builder's
+   compile message: both were .status, and the later rule was quietly overriding
+   this one's size and colour — the pill asks for .62rem in accent and rendered
+   at .7rem in muted grey. */
+.statustag{
   font-family:var(--mono); font-size:.62rem; letter-spacing:.08em; text-transform:uppercase;
   color:var(--accent); background:var(--accent-soft); border:1px solid var(--accent-line);
   border-radius:.25rem; padding:.1rem .38rem; vertical-align:.1em; margin-left:.4rem;


### PR DESCRIPTION
The publications page marks a submitted paper with a pill and the PDF prints `(submitted)` after the venue, but the CV page said nothing at all. Unlike the PDF it does not group by status, so a submitted paper was indistinguishable from a published one.

It now carries the same pill, in the same place — straight after the title.

```
Coordinax: an extended framework for coordinates …  [IN-PREP]  — N. Starkman, A. Price-Whelan
```

10 pills on the complete CV: 6 `submitted`, 4 `in-prep`.

## A collision this turned up

The pill and the builder's compile message were **both `.status`**, and the builder's rule — later in the file — was quietly overriding the pill on the publications page:

```
asked for   .62rem  var(--accent)      →  9.92px  rgb(42,93,168)
rendered    .7rem   var(--ink-mute)    →  11.2px  rgb(90,100,114)
```

So the pill has been the wrong size and colour on `/publications/` for as long as both rules have existed.

**Scoping one of them was not enough.** I tried `.builderbar .status` first; that fixed the size and colour, but the pill's `background`, `border` and `padding` still leaked onto the compile message, which came out sitting in a blue pill of its own. The pill is now `.statustag`, so the two selectors cannot reach each other at all.

Verified both after the change:

```
pill             9.92px  rgb(42,93,168)  on rgb(234,240,249)   ✓
builder message  11.2px  rgb(90,100,114) on transparent        ✓
```

## Scope

`status` is a publication-only field in the schema, so the condition needs no type guard. `published` shows nothing, as before.

103 unit tests, 775 links, a11y across 9 pages, page contracts hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
