### PR TITLE
Link a publication's venue to its article at the journal

### DIFF
--- a/data/2022-08-astropy-v5-paper.json
+++ b/data/2022-08-astropy-v5-paper.json
@@ -45,6 +45,7 @@
   "arxiv": "2206.14220",
   "primaryClass": "astro-ph.IM",
   "bibcode": "2022ApJ...935..167A",
+  "doi": "10.3847/1538-4357/ac7c74",
   "citations": 2200,
   "links": [
     {

--- a/data/2025-streamsculptor.json
+++ b/data/2025-streamsculptor.json
@@ -31,10 +31,13 @@
     }
   ],
   "venue": {
-    "journal": "The Astrophysical Journal"
+    "journal": "The Astrophysical Journal",
+    "volume": "983",
+    "pages": "68"
   },
   "arxiv": "2410.21174",
   "bibcode": "2024arXiv241021174N",
+  "doi": "10.3847/1538-4357/adb8e8",
   "tags": [
     "streams",
     "dynamics"

--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -3,7 +3,8 @@
 // never drift.
 import CvHeader from './CvHeader.astro';
 import { presetNames, preset, resolve, sectionIndex } from '../lib/presets.js';
-import { dateLabel, authors, venueLine, links, REL_ICON, relKey } from '../lib/data.js';
+import { dateLabel, authors, venueLine,
+  venueUrl, links, REL_ICON, relKey } from '../lib/data.js';
 import { spans, detailLines } from '../lib/inline.js';
 import LinkIcons from './LinkIcons.astro';
 
@@ -166,7 +167,9 @@ const money = (a) => {
                       : a.name}</>
                 ))}{authors(item, 4).etal && <>, et al</>}
                 {(authors(item, 4).etal || venueLine(item)) && '.'}
-                {venueLine(item) && <> <span class="venue">{venueLine(item)}</span></>}
+                {venueLine(item) && <> {venueUrl(item)
+                  ? <a class="venue venuelink" href={venueUrl(item)}>{venueLine(item)}</a>
+                  : <span class="venue">{venueLine(item)}</span>}</>}
               </>
             )}
             {/* Grants show their figure; awards keep theirs in the record only. */}

--- a/src/components/Publication.astro
+++ b/src/components/Publication.astro
@@ -1,7 +1,7 @@
 ---
 // One publication. `brief` is the landing-page variant: year and a single
 // `paper` button stacked in the right-hand column, everything else dropped.
-import { authors, venueLine, year, links, authorPosition } from '../lib/data.js';
+import { authors, venueLine, year, links, authorPosition, venueUrl } from '../lib/data.js';
 import { mathParts } from '../lib/maths.js';
 import LinkIcons from './LinkIcons.astro';
 
@@ -9,6 +9,7 @@ const { item, brief = false, maxAuthors = 8, abstract = false } = Astro.props;
 
 const { shown, etal, collaboration } = authors(item, brief ? 3 : maxAuthors);
 const venue = venueLine(item);
+const venueHref = venueUrl(item);
 const all = links(item);
 const paper = all.find((l) => l.rel === 'paper') ?? all.find((l) => l.rel === 'preprint');
 const trail = brief ? [] : all;
@@ -34,12 +35,16 @@ const pos = authorPosition(item);
             : a.name}</>
       ))}
       {etal && <>, et al.</>}
-      {brief && venue && <> · <span class="venue">{venue}</span></>}
+      {brief && venue && <> · {venueHref
+        ? <a class="venue venuelink" href={venueHref}>{venue}</a>
+        : <span class="venue">{venue}</span>}</>}
     </p>
 
     {!brief && (venue || item.arxiv) && (
       <p class="venueline">
-        {venue && <span class="venue">{venue}</span>}
+        {venue && (venueHref
+          ? <a class="venue venuelink" href={venueHref}>{venue}</a>
+          : <span class="venue">{venue}</span>)}
         {venue && <span class="dot">·</span>}
         {!venue && item.arxiv && <>arXiv:{item.arxiv}<span class="dot">·</span></>}
         <span class="yr">{year(item)}</span>

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -88,6 +88,26 @@ export function authorPosition(item) {
   return i === -1 ? null : i + 1;
 }
 
+/**
+ * The article's page at the journal, or null.
+ *
+ * Only for published work: a submitted paper has no article page, and pointing
+ * its venue at an arXiv DOI would claim otherwise.
+ *
+ * The record's own `paper` link wins over the DOI because it is the curated
+ * one — often the publisher's own reader rather than the doi.org redirect. The
+ * ADS link that `links()` synthesises from a bibcode is deliberately not used:
+ * ADS is a database record about the paper, not the journal's page for it.
+ */
+export function venueUrl(item) {
+  if (item.status !== 'published') return null;
+  const curated = (item.links ?? []).find((l) => l.rel === 'paper' && l.url);
+  if (curated) return curated.url;
+  // 10.48550 is arXiv's own prefix — a preprint DOI, not a journal article.
+  if (item.doi && !item.doi.startsWith('10.48550/')) return `https://doi.org/${item.doi}`;
+  return null;
+}
+
 /** Where a co-author's name points. ORCID is the identifier, so it is the link. */
 export const orcidUrl = (orcid) => (orcid ? `https://orcid.org/${orcid}` : null);
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -522,6 +522,11 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 }
 
 
+/* The venue, linked to the article at the journal. Same restraint as an author
+   link: it reads as the citation it is, and shows it is a link on hover. */
+.venuelink{color:inherit; text-decoration:none; border-bottom:1px solid transparent}
+.venuelink:hover, .venuelink:focus-visible{color:var(--accent); border-bottom-color:var(--accent-line)}
+
 .authorlink{color:inherit; text-decoration:none; border-bottom:1px solid transparent}
 .authorlink:hover, .authorlink:focus-visible{color:var(--accent); border-bottom-color:var(--accent-line)}
 .tl{scroll-margin-top:5rem}

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -7,6 +7,7 @@ import {
   byType,
   resolve,
   authorPosition,
+  venueUrl,
   displayName,
   authors,
   venueLine,
@@ -200,5 +201,43 @@ describe('authorPosition', () => {
   it('is null when the owner is not an author', () => {
     expect(authorPosition({ authors: [{ family: 'Someone' }] })).toBeNull();
     expect(authorPosition({})).toBeNull();
+  });
+});
+
+describe('venueUrl', () => {
+  it('points a published paper at its article', () => {
+    // The curated `paper` link wins: it is the publisher's own reader.
+    expect(venueUrl(resolve('stream-members-only')))
+      .toBe('https://iopscience.iop.org/article/10.3847/1538-4357/ad94f2');
+  });
+
+  it('falls back to the DOI when there is no curated link', () => {
+    expect(venueUrl(resolve('astropy-v5-paper'))).toBe('https://doi.org/10.3847/1538-4357/ac7c74');
+  });
+
+  it('gives a submitted paper no article link, because there is no article', () => {
+    expect(venueUrl(resolve('pinns-mnras'))).toBeNull();
+    expect(venueUrl(resolve('potamides-apj'))).toBeNull();
+  });
+
+  it('never points a venue at an arXiv DOI', () => {
+    // euclid-eggs-pilot carries 10.48550/arXiv.… — a preprint DOI. Linking the
+    // journal name to it would assert a publication that has not happened.
+    const euclid = resolve('euclid-eggs-pilot');
+    expect(euclid.doi).toMatch(/^10\.48550\//);
+    expect(venueUrl(euclid)).toBeNull();
+  });
+
+  it('does not send a venue to ADS, which is a record about the paper', () => {
+    for (const p of byType('publication')) {
+      expect(venueUrl(p) ?? '').not.toContain('adsabs');
+    }
+  });
+
+  it('links every published paper that names a venue', () => {
+    const missing = byType('publication')
+      .filter((p) => p.status === 'published' && (p.venue?.journal || p.venue?.booktitle))
+      .filter((p) => !venueUrl(p));
+    expect(missing.map((p) => p.id)).toEqual([]);
   });
 });


### PR DESCRIPTION
The venue read as plain text everywhere — "The Astrophysical Journal 980, 253" named the article without reaching it. It is now a link, **on the website only**; `cv/cv.typ` is untouched and the PDFs are unchanged.

**11 linked, 5 not** — every published paper, and no submitted or in-preparation one.

## Two papers had no article link at all

This is why it needed lookups rather than only rendering:

| | | |
|---|---|---|
| `streamsculptor` | ApJ **983, 68** | `10.3847/1538-4357/adb8e8` |
| `astropy-v5-paper` | ApJ 935, 167 | `10.3847/1538-4357/ac7c74` |

`streamsculptor` was the worse of the two: marked published, but carrying its **arXiv** bibcode (`2024arXiv241021174N`), no DOI and no article number, so its venue rendered as the bare journal name. It has been out since 2025 as ApJ 983, 68.

Both DOIs were verified against Crossref — title, journal, volume, page and author list — before being written, not taken from a fuzzy title match.

## What `venueUrl` refuses to link matters as much as what it links

- **Published only.** A submitted paper has no article page.
- **The record's `paper` link wins over the DOI** — it is the publisher's own reader rather than a `doi.org` redirect.
- **Never the ADS link** that `links()` synthesises from a bibcode. ADS is a record *about* the paper, not the journal's page for it.
- **Never a `10.48550` DOI** — that is arXiv's own prefix. `euclid-eggs-pilot` carries one; pointing "Astronomy & Astrophysics" at it would assert a publication that has not happened.

Each of those is a test.

## No schema change

`doi` and `links[rel=paper]` were already in the schema, so this needed data and rendering only.

## Verified

All 11 URLs checked. Eight return 200; three return 403 — `academic.oup.com` and `journals.aps.org` block scripted requests. I confirmed those are real rather than broken by resolving each DOI through the Crossref API, which returns the expected journal and title for every one.

109 unit tests (6 new), schema, bibtex — the two new DOIs now appear in the `.bib` — 802 links, a11y across 9 pages, page contracts hold.

> Loose end I could not settle here: `streamsculptor` still has its arXiv bibcode, so its ADS link points at the eprint rather than the published article. ADS returns 405 to scripted requests, so I could not confirm the published bibcode and would rather not construct one by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
