### PR TITLE
Select publications by author position in the builder

### DIFF
--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -4,9 +4,30 @@
 import CvHeader from './CvHeader.astro';
 import { presetNames, preset, resolve, sectionIndex } from '../lib/presets.js';
 import { dateLabel, authors, venueLine,
-  venueUrl, links, REL_ICON, relKey } from '../lib/data.js';
+  venueUrl, links, REL_ICON, relKey, authorPosition } from '../lib/data.js';
 import { spans, detailLines } from '../lib/inline.js';
 import LinkIcons from './LinkIcons.astro';
+
+/**
+ * Author-position stops for the publications selector, from the section's own
+ * items. A stop that admits the same papers as the one before it, or as all of
+ * them, is a button that does nothing — with positions 1, 2 and 4 that leaves
+ * 1 and 2, and None/All bracket them.
+ */
+function posStops(section) {
+  const positions = section.items
+    .filter((i) => i.type === 'publication')
+    .map(authorPosition)
+    .filter((n) => n != null);
+  if (positions.length === 0) return [];
+  const stops = [];
+  for (let n = 1; n <= 4; n += 1) {
+    const count = positions.filter((p) => p <= n).length;
+    const previous = stops.length ? stops[stops.length - 1].count : 0;
+    if (count > previous && count < positions.length) stops.push({ n, count });
+  }
+  return stops.map((s2) => s2.n);
+}
 
 // `pick` turns the same CV into the builder's picker: every entry keeps its
 // full rendering and gains a checkbox. Reading what you are selecting is the
@@ -74,6 +95,20 @@ const money = (a) => {
       )}
       <h3 class="cvsection" id={s.id}>{s.heading}</h3>
       {collapsed && <span class="cvcount">{s.items.length}</span>}
+      {/* Publications only, and only in the picker. The section checkbox is all
+          or nothing; this is the same author-position cut the publications page
+          offers, so a first-author CV is one click rather than nineteen. Hidden
+          until the heading is hovered or something inside it takes focus, so it
+          does not compete with the headings that have no such control. */}
+      {selectable && s.id === 'publications' && posStops(s).length > 0 && (
+        <span class="possel" role="group" aria-label="Select publications by author position">
+          <button type="button" class="posbtn" data-possel="none">None</button>
+          {posStops(s).map((n) => (
+            <button type="button" class="posbtn" data-possel={n}>{n}</button>
+          ))}
+          <button type="button" class="posbtn" data-possel="all">All</button>
+        </span>
+      )}
       {selectable && s.items.some((i) => detail(i).length > 0) && (
         <label class="subgrouplab">
           <input type="checkbox" class="subgroup" checked={level === 'full'}
@@ -133,6 +168,8 @@ const money = (a) => {
              id={`item-${item.id}`}>
           {pick && (
             <input type="checkbox" class="itembox" value={item.id}
+                   data-pos={item.type === 'publication'
+                     ? (authorPosition(item) ?? undefined) : undefined}
                    checked={isPicked(item.id)}
                    aria-label={`Include ${item.title}`} />
           )}

--- a/src/pages/cv/builder.astro
+++ b/src/pages/cv/builder.astro
@@ -136,6 +136,27 @@ const site = buildInfo();
         boxes().forEach((b) => (b.checked = t.dataset.all === '1'));
         recount();
       }
+      if (t.dataset.possel !== undefined) {
+        // Scoped to the section the button sits in, so it can never reach
+        // another section's entries.
+        const group = t.closest('.pickgroup');
+        const want = t.dataset.possel;
+        let on = 0;
+        for (const b of group.querySelectorAll('.itembox')) {
+          const pos = Number(b.dataset.pos);
+          // An entry with no position — no author marked `me` — is not a paper
+          // this cut can speak about, so only "all" and "none" touch it.
+          const keep = want === 'all' ? true
+            : want === 'none' ? false
+            : Number.isFinite(pos) && pos <= Number(want);
+          b.checked = keep;
+          if (keep) on += 1;
+        }
+        recount();
+        status(want === 'none' ? 'Publications cleared.'
+          : want === 'all' ? `All ${on} publications selected.`
+          : `${on} publications with author position ${want} or better.`);
+      }
       if (t.dataset.preset) {
         const ids = new Set(MEMBERSHIP[t.dataset.preset] ?? []);
         boxes().forEach((b) => (b.checked = ids.has(b.value)));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -456,8 +456,13 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
    hovered — or something inside it takes focus, which is what keeps it
    reachable by keyboard: pointer-events go with the opacity, so an invisible
    button is never clickable, but tabbing to it reveals it. */
-.possel{display:inline-flex; gap:.15rem; margin-left:.5rem;
+/* margin-left:auto puts it in the right-hand cluster with `detail`, rather
+   than immediately after the heading where it crowded the title. When `detail`
+   is also present it follows this, so the two read as one group of controls. */
+.possel{display:inline-flex; gap:.15rem; margin-left:auto;
   opacity:0; pointer-events:none; transition:opacity .15s ease}
+/* Once .possel has taken the auto margin, `detail` must not also claim it. */
+.possel ~ .subgrouplab{margin-left:0}
 .cvsechead:hover .possel, .cvsechead:focus-within .possel{opacity:1; pointer-events:auto}
 @media (prefers-reduced-motion:reduce){ .possel{transition:none} }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -452,6 +452,23 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 .baremark .ico{width:17px; height:17px; fill:currentColor; display:block}
 .baremark:hover, .baremark:focus-visible{color:var(--accent)}
 
+/* The builder's per-publication selector. Out of the way until the heading is
+   hovered — or something inside it takes focus, which is what keeps it
+   reachable by keyboard: pointer-events go with the opacity, so an invisible
+   button is never clickable, but tabbing to it reveals it. */
+.possel{display:inline-flex; gap:.15rem; margin-left:.5rem;
+  opacity:0; pointer-events:none; transition:opacity .15s ease}
+.cvsechead:hover .possel, .cvsechead:focus-within .possel{opacity:1; pointer-events:auto}
+@media (prefers-reduced-motion:reduce){ .possel{transition:none} }
+
+.posbtn{
+  font-family:var(--mono); font-size:.6rem; letter-spacing:.04em; text-transform:uppercase;
+  color:var(--ink-mute); background:var(--surface);
+  border:1px solid var(--rule-strong); border-radius:999px;
+  padding:.05rem .4rem; cursor:pointer; line-height:1.5;
+}
+.posbtn:hover{color:var(--accent); border-color:var(--accent-line); background:var(--accent-soft)}
+
 /* ---------- publications: filter by author position ---------- */
 /* Clipped rather than display:none — a display:none radio is not focusable, and
    this has to be reachable and arrow-navigable like any other radio group. */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -456,13 +456,11 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
    hovered — or something inside it takes focus, which is what keeps it
    reachable by keyboard: pointer-events go with the opacity, so an invisible
    button is never clickable, but tabbing to it reveals it. */
-/* margin-left:auto puts it in the right-hand cluster with `detail`, rather
-   than immediately after the heading where it crowded the title. When `detail`
-   is also present it follows this, so the two read as one group of controls. */
-.possel{display:inline-flex; gap:.15rem; margin-left:auto;
+/* Left, following the heading — not pushed to the right-hand cluster, which is
+   where `detail` lives. The gap is the heading row's own, so it clears the
+   title rather than sitting against it. */
+.possel{display:inline-flex; gap:.15rem;
   opacity:0; pointer-events:none; transition:opacity .15s ease}
-/* Once .possel has taken the auto margin, `detail` must not also claim it. */
-.possel ~ .subgrouplab{margin-left:0}
 .cvsechead:hover .possel, .cvsechead:focus-within .possel{opacity:1; pointer-events:auto}
 @media (prefers-reduced-motion:reduce){ .possel{transition:none} }
 
@@ -560,7 +558,11 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 
 /* Section head carries the rule, so the heading and its toggle sit on one line. */
 .cvsechead{
-  display:flex; align-items:baseline; justify-content:flex-start; gap:1rem;
+  /* Centred, not baseline. The row mixes a heading with a checkbox, a pill
+     group and a small label, none of which share a text baseline — under
+     `baseline` they sat at three different heights, spread over 3.2px, with
+     `detail` riding highest and the selector lowest. */
+  display:flex; align-items:center; justify-content:flex-start; gap:1rem;
   margin:1.6rem 0 .3rem; padding-bottom:.3rem; border-bottom:1px solid var(--rule);
 }
 .cvsec--first .cvsechead{margin-top:1rem}


### PR DESCRIPTION
The section checkbox is all or nothing. Hovering the **Publications** heading in the builder now reveals a finer cut:

```
☑ Publications   [None] [1] [2] [All]        detail ☑
```

Same author-position idea as the publications page, so a first-author CV is one click rather than nineteen. **The section checkbox is unchanged** — this sits beside it.

Publications only, and only in the picker.

## Answering the question you asked

**The reveal is pure CSS. Applying the selection is not, and cannot be.** CSS can style based on a checkbox's state but cannot *set* another element's `checked` — there is no selector-based way to tick thirteen boxes from one control.

That costs nothing here, because **the section checkbox it sits next to is already JavaScript**: `builder.astro` listens for `change` on `.groupbox` and propagates to the `.itembox`es. The builder is a compile tool that cannot do anything without JS, so this adds no new dependency. Everywhere that genuinely works without JS still does.

## Stops come from the data

A stop admitting the same papers as the one before it, or as all of them, is a button that does nothing. Positions present in the picker are 1 (13 papers), 2 (5) and 4 (3), so it renders `1` and `2`, bracketed by `None` and `All` — no dead buttons, and a `3` would appear on its own if a third-author paper ever did.

## Verified

```
None →  0 checked
1    → 13 checked   positions [1]
2    → 18 checked   positions [1,2]
All  → 21 checked   positions [1,2,4]
```

Scoped correctly: with every box on the page ticked, pressing `None` left all fourteen other sections untouched (`otherSectionsUnchanged: true`), and no other section renders the control.

`pointer-events` travels with the opacity, so the buttons are never clickable while invisible, and `:focus-within` reveals them for a keyboard:

```
rest   opacity 0  pointer-events none
shown  opacity 1  pointer-events auto
```

An entry with no author position — no author marked `me` — is touched only by `None` and `All`, since the cut has nothing to say about it.

> Caveat on testing: `:hover` and `:focus-within` cannot be exercised here. The automation tab reports `document.hasFocus() === false`, so `:focus-within` never matches, and CSS hover does not respond to synthetic events. I verified the declarations apply and the gating is right; the selectors themselves are ordinary CSS.

109 unit tests, 802 links, a11y across 9 pages, page contracts hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
