### PR TITLE
Stop collapsing Publications and Software on the CV

### DIFF
--- a/config/presets.json
+++ b/config/presets.json
@@ -30,7 +30,6 @@
         },
         "layout": "publications",
         "groupBy": "status",
-        "collapsed": true,
         "page": "/publications/"
       },
       {
@@ -59,7 +58,6 @@
           "type": "software"
         },
         "layout": "grid",
-        "collapsed": true,
         "page": "/software/"
       },
       {
@@ -184,7 +182,6 @@
         },
         "layout": "publications",
         "groupBy": "status",
-        "collapsed": true,
         "page": "/publications/"
       },
       {
@@ -213,7 +210,6 @@
           "type": "software"
         },
         "layout": "grid",
-        "collapsed": true,
         "page": "/software/"
       },
       {
@@ -339,7 +335,6 @@
         "layout": "publications",
         "limit": 10,
         "groupBy": "status",
-        "collapsed": true,
         "page": "/publications/"
       },
       {
@@ -370,7 +365,6 @@
           "type": "software"
         },
         "layout": "grid",
-        "collapsed": true,
         "page": "/software/",
         "limit": 5
       },
@@ -443,7 +437,6 @@
         },
         "layout": "publications",
         "limit": 5,
-        "collapsed": true,
         "page": "/publications/"
       },
       {
@@ -465,7 +458,6 @@
         },
         "limit": 4,
         "layout": "grid",
-        "collapsed": true,
         "page": "/software/"
       }
     ]


### PR DESCRIPTION
Both sections opened behind a `<details>` on every preset, so the two a reader most wants — Publications and Software — were the two they had to click for. They now render open like every other section.

**Config only.** Eight `"collapsed": true` entries removed: two sections across four presets.

```
config/presets.json | 8 --------
```

## Verified

No `<details>` and no count badges left on any CV page, and every entry renders:

| | publications | software |
|---|---|---|
| `/cv/` | 17 | 5 |
| `/cv/complete/` | 21 | 22 |

`/cv/1page/` and `/cv/builder/` likewise carry no disclosure. The builder was already unaffected — it forces sections open in picker mode — so this only changes the reading views.

## What I did not remove

The collapse mechanism itself stays in `presets.js` and `CvView.astro`. It is a supported config option that nothing currently uses, and keeping it means turning a section back into a disclosure is one line rather than a rewrite. Say the word if you would rather it went entirely.

109 unit tests, 802 links, a11y across 9 pages, page contracts hold — the PDFs never had disclosures, so they are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
