### PR TITLE
Point StreamSculptor's ADS link at the published article

### DIFF
--- a/data/2025-streamsculptor.json
+++ b/data/2025-streamsculptor.json
@@ -36,7 +36,7 @@
     "pages": "68"
   },
   "arxiv": "2410.21174",
-  "bibcode": "2024arXiv241021174N",
+  "bibcode": "2025ApJ...983...68N",
   "doi": "10.3847/1538-4357/adb8e8",
   "tags": [
     "streams",


### PR DESCRIPTION
Closes the loose end from #36.

The record still carried its **eprint** bibcode, `2024arXiv241021174N`, so its ADS link went to the preprint rather than to ApJ 983, 68 — which is where the venue link, added in #36, already points.

```
- "bibcode": "2024arXiv241021174N"
+ "bibcode": "2025ApJ...983...68N"
```

## Verified, not constructed

I said in #36 I would rather not hand-build a bibcode. ADS returns 405 to a plain scripted request, but its **link gateway** answers:

```
https://ui.adsabs.harvard.edu/link_gateway/2025ApJ...983...68N/PUB_HTML
  302 → https://doi.org/10.3847/1538-4357/adb8e8
```

That is exactly the DOI already on the record, so the bibcode and the DOI describe the same article.

The page now emits `https://ui.adsabs.harvard.edu/abs/2025ApJ...983...68N/abstract`.

Schema, bibtex, 109 unit tests, 802 links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)