### PR TITLE
Filter software by whether it has a paper, and link to it

### DIFF
--- a/src/components/SoftwareSection.astro
+++ b/src/components/SoftwareSection.astro
@@ -1,7 +1,7 @@
 ---
 // Three tiers, two dividers: the lead package, the headliners as cards, then
 // everything else compactly. Tier comes from the data, not from an id check.
-import { byType, links } from '../lib/data.js';
+import { byType, links, softwarePaper } from '../lib/data.js';
 import LinkIcons from './LinkIcons.astro';
 
 // The landing page shows the lead and the headliners only; the long tail is
@@ -15,22 +15,31 @@ const other = (tail ? all.filter((s) => s.tier === 'other') : [])
   .sort((a, b) => a.title.localeCompare(b.title));
 
 const href = (s) => links(s)[0]?.url ?? '#';
+// The paper leads the trail where there is one: it is the citable artefact,
+// and the package's own code and docs links are already beside it.
+const trail = (s) => {
+  const paper = softwarePaper(s);
+  return paper ? [paper, ...links(s)] : links(s);
+};
+// Marks the card for the filter — present or absent, so the CSS tests for the
+// attribute. An empty string is dropped from the output, hence the value.
+const hasPaper = (s) => (softwarePaper(s) ? 'yes' : undefined);
 ---
 {lead && (
-  <div class="lead">
+  <div class="lead" data-paper={hasPaper(lead)}>
     <div class="name"><a href={href(lead)}>{lead.title}</a></div>
     {lead.role && <div class="role-line">{lead.role}</div>}
     <p>{lead.details ?? lead.summary}</p>
-    <LinkIcons links={links(lead)} />
+    <LinkIcons links={trail(lead)} />
   </div>
 )}
 
 <div class="soft">
   {headline.map((s) => (
-    <div class="card">
+    <div class="card" data-paper={hasPaper(s)}>
       <div class="name"><a href={href(s)}>{s.title}</a></div>
       <p>{s.details ?? s.summary}</p>
-      <LinkIcons links={links(s)} />
+      <LinkIcons links={trail(s)} />
     </div>
   ))}
 </div>
@@ -40,10 +49,10 @@ const href = (s) => links(s)[0]?.url ?? '#';
     <div class="tierbreak" role="presentation"></div>
     <div class="soft soft--mini">
       {other.map((s) => (
-        <div class="card card--mini">
+        <div class="card card--mini" data-paper={hasPaper(s)}>
           <div class="name"><a href={href(s)}>{s.title}</a></div>
           <p>{s.summary}</p>
-          <LinkIcons links={links(s)} />
+          <LinkIcons links={trail(s)} />
         </div>
       ))}
     </div>

--- a/src/lib/cvmodel.js
+++ b/src/lib/cvmodel.js
@@ -7,7 +7,7 @@
 
 import person from '/config/person.json';
 import { resolve } from './presets.js';
-import { authors, venueLine, dateLabel, links, resolve as item0, REL_ICON, relKey } from './data.js';
+import { authors, venueLine, dateLabel, links, resolve as item0, softwarePaper, REL_ICON, relKey } from './data.js';
 import { spans, detailLines } from './inline.js';
 
 /**
@@ -70,21 +70,12 @@ function subject(item) {
  * Awards keep their figure in the record but do not print it — a fellowship is
  * not usefully described by its stipend, and a grant is.
  */
-/**
- * A package's paper, where the record points at one. `unxt` refs `unxt-joss`
- * and `astropy` refs the v5 paper, but the software entry carried only its own
- * code and docs links — so a published package looked unpublished.
- */
-const CITE = ['paper', 'preprint', 'doi'];
-function paperOf(sw) {
-  for (const id of sw.refs ?? []) {
-    const ref = item0(id);
-    if (ref?.type !== 'publication') continue;
-    const cite = links(ref).find((l) => CITE.includes(l.rel));
-    if (cite) return { rel: 'paper', url: cite.url, label: 'paper', icon: 'paper' };
-  }
-  return null;
-}
+/** One definition, in lib/data.js, so the PDF and the website cannot disagree
+ *  about which packages have a paper. The template wants an `icon`. */
+const paperOf = (sw) => {
+  const p = softwarePaper(sw);
+  return p ? { ...p, icon: 'paper' } : null;
+};
 
 /** The byline, with the CV's owner bold.
  *

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -108,6 +108,35 @@ export function venueUrl(item) {
   return null;
 }
 
+/**
+ * A package's paper, where the record points at one.
+ *
+ * `unxt` refs `unxt-joss`, `astropy` refs the v5 paper, `trackstream` refs the
+ * stream-tracks paper. The software entry itself carries only code and docs
+ * links, so without following the ref a published package looks unpublished.
+ *
+ * `refs` is not a paper field: `coordinax` refs `unxt`, another package. Hence
+ * the type check — it is what stops a package being called published because
+ * it happens to point at a sibling.
+ */
+const CITE_RELS = ['paper', 'preprint', 'doi'];
+export function softwarePaper(sw) {
+  for (const id of sw.refs ?? []) {
+    const ref = resolve(id);
+    if (ref?.type !== 'publication') continue;
+    // The article at the journal first. Taking the first citation link instead
+    // sent Astropy to its ADS record and macro_lightning to its arXiv preprint,
+    // because REL_ORDER ranks `ads` and `preprint` above `paper` — right for a
+    // trail of marks, wrong when only one link is being chosen.
+    const article = venueUrl(ref);
+    if (article) return { rel: 'paper', url: article, label: 'paper', id: ref.id, status: ref.status };
+    // Nothing published yet: a preprint or a review thread is what there is.
+    const cite = links(ref).find((l) => CITE_RELS.includes(l.rel));
+    if (cite) return { rel: 'paper', url: cite.url, label: 'paper', id: ref.id, status: ref.status };
+  }
+  return null;
+}
+
 /** Where a co-author's name points. ORCID is the identifier, so it is the link. */
 export const orcidUrl = (orcid) => (orcid ? `https://orcid.org/${orcid}` : null);
 

--- a/src/pages/software.astro
+++ b/src/pages/software.astro
@@ -1,12 +1,32 @@
 ---
 import Base from '../layouts/Base.astro';
 import SoftwareSection from '../components/SoftwareSection.astro';
+import { byType, softwarePaper } from '../lib/data.js';
+
+const all = byType('software');
+const withPaper = all.filter(softwarePaper).length;
 ---
 <Base title="Software — Nathaniel Starkman">
   <main>
     <section>
       <div class="wrap">
-        <h2>Software</h2>
+        {/* Direct children of .wrap and ahead of the cards, so the filter is a
+            plain sibling selector on :checked — no JavaScript. Clipped rather
+            than display:none so they stay focusable and arrow-navigable. */}
+        <input type="radio" name="sw" id="sw-all" class="posradio" checked />
+        <input type="radio" name="sw" id="sw-yes" class="posradio" />
+        <input type="radio" name="sw" id="sw-no" class="posradio" />
+
+        <div class="h2row">
+          <h2>Software</h2>
+          <span class="more">
+            <span class="pubfilter" data-stops="3">
+              <label for="sw-all" title={`All ${all.length} packages`}>All</label>
+              <label for="sw-yes" title={`${withPaper} packages with a paper`}>Paper</label>
+              <label for="sw-no" title={`${all.length - withPaper} packages without one`}>None</label>
+            </span>
+          </span>
+        </div>
         <SoftwareSection />
       </div>
     </section>

--- a/src/pages/software.astro
+++ b/src/pages/software.astro
@@ -15,15 +15,13 @@ const withPaper = all.filter(softwarePaper).length;
             than display:none so they stay focusable and arrow-navigable. */}
         <input type="radio" name="sw" id="sw-all" class="posradio" checked />
         <input type="radio" name="sw" id="sw-yes" class="posradio" />
-        <input type="radio" name="sw" id="sw-no" class="posradio" />
 
         <div class="h2row">
           <h2>Software</h2>
           <span class="more">
-            <span class="pubfilter" data-stops="3">
+            <span class="pubfilter" data-stops="2">
               <label for="sw-all" title={`All ${all.length} packages`}>All</label>
               <label for="sw-yes" title={`${withPaper} packages with a paper`}>Paper</label>
-              <label for="sw-no" title={`${all.length - withPaper} packages without one`}>None</label>
             </span>
           </span>
         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -472,6 +472,25 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 }
 .posbtn:hover{color:var(--accent); border-color:var(--accent-line); background:var(--accent-soft)}
 
+/* ---------- software: filter by whether a package has a paper ---------- */
+/* The thumb positions reuse .pubfilter; only the hiding differs. `data-paper`
+   is present or absent rather than true/false, so these test the attribute. */
+#sw-all:checked ~ .h2row .pubfilter::before{transform:translateX(0)}
+#sw-yes:checked ~ .h2row .pubfilter::before{transform:translateX(100%)}
+#sw-no:checked  ~ .h2row .pubfilter::before{transform:translateX(200%)}
+#sw-all:checked ~ .h2row .pubfilter label[for="sw-all"],
+#sw-yes:checked ~ .h2row .pubfilter label[for="sw-yes"],
+#sw-no:checked  ~ .h2row .pubfilter label[for="sw-no"]{color:var(--ink)}
+.posradio:focus-visible ~ .h2row .pubfilter{outline:2px solid var(--accent); outline-offset:2px}
+
+#sw-yes:checked ~ .lead:not([data-paper]),
+#sw-yes:checked ~ .soft .card:not([data-paper]),
+#sw-no:checked ~ .lead[data-paper],
+#sw-no:checked ~ .soft .card[data-paper]{display:none}
+/* The divider between the headliners and the tail is only meaningful when both
+   are showing. */
+#sw-yes:checked ~ .tierbreak, #sw-no:checked ~ .tierbreak{display:none}
+
 /* ---------- publications: filter by author position ---------- */
 /* Clipped rather than display:none — a display:none radio is not focusable, and
    this has to be reachable and arrow-navigable like any other radio group. */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -194,8 +194,8 @@ h2{
    list down to one card made it stretch the full width while the row beneath
    stayed three-up. auto-fill keeps the tracks, so a card is the same width
    whether it has neighbours or not. */
-.soft{display:grid; grid-template-columns:repeat(auto-fill,minmax(15rem,1fr));
-  gap:.9rem; grid-auto-rows:1fr}
+.soft{display:grid; grid-template-columns:repeat(auto-fill,minmax(13rem,1fr));
+  gap:.7rem; grid-auto-rows:1fr}
 .card{
   display:flex; flex-direction:column; gap:.3rem;
   /* A whisper of a squircle — enough to group the cards, not enough to draw a
@@ -276,7 +276,11 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 /* Software tier 3: the long tail. Same card, three across instead of two, and
    dialled down — smaller type, tighter padding, shorter box. Same aesthetic, a
    quieter voice, so the four headliners still lead. */
-.soft--mini{grid-template-columns:repeat(auto-fill,minmax(13rem,1fr)); gap:.7rem}
+/* No column override: the headline grid and this one share tracks and gap, so
+   a card in either lines up with the card above it. They differed — 15rem/.9rem
+   against 13rem/.7rem — which resolved to two columns over three, and nothing
+   in the two rows ever aligned. The tiers still read apart, by padding, radius
+   and type size on .card--mini rather than by column width. */
 .card--mini{padding:.7rem .8rem .75rem; border-radius:12px; gap:.2rem}
 .card--mini .name{font-size:.85rem; overflow-wrap:anywhere}
 .card--mini .name .stars{font-size:.66rem}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -494,9 +494,10 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 
 #sw-yes:checked ~ .lead:not([data-paper]),
 #sw-yes:checked ~ .soft .card:not([data-paper]){display:none}
-/* The divider between the headliners and the tail is only meaningful when both
-   are showing. */
-#sw-yes:checked ~ .tierbreak{display:none}
+/* The tier divider stays. Hiding it took its margins with it — the only thing
+   separating the two grids — so the filtered headline card ran straight into
+   the row beneath. Both tiers keep visible cards under either stop, so the
+   divider is still saying something true. */
 
 /* ---------- publications: filter by author position ---------- */
 /* Clipped rather than display:none — a display:none radio is not focusable, and

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -190,7 +190,11 @@ h2{
   color:var(--accent);
 }
 .lead p{margin:0; font-size:1rem; color:var(--ink-2); line-height:1.55}
-.soft{display:grid; grid-template-columns:repeat(auto-fit,minmax(15rem,1fr));
+/* auto-fill, not auto-fit: auto-fit collapses the empty tracks, so filtering the
+   list down to one card made it stretch the full width while the row beneath
+   stayed three-up. auto-fill keeps the tracks, so a card is the same width
+   whether it has neighbours or not. */
+.soft{display:grid; grid-template-columns:repeat(auto-fill,minmax(15rem,1fr));
   gap:.9rem; grid-auto-rows:1fr}
 .card{
   display:flex; flex-direction:column; gap:.3rem;
@@ -272,7 +276,7 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 /* Software tier 3: the long tail. Same card, three across instead of two, and
    dialled down — smaller type, tighter padding, shorter box. Same aesthetic, a
    quieter voice, so the four headliners still lead. */
-.soft--mini{grid-template-columns:repeat(auto-fit,minmax(13rem,1fr)); gap:.7rem}
+.soft--mini{grid-template-columns:repeat(auto-fill,minmax(13rem,1fr)); gap:.7rem}
 .card--mini{padding:.7rem .8rem .75rem; border-radius:12px; gap:.2rem}
 .card--mini .name{font-size:.85rem; overflow-wrap:anywhere}
 .card--mini .name .stars{font-size:.66rem}
@@ -473,23 +477,22 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 .posbtn:hover{color:var(--accent); border-color:var(--accent-line); background:var(--accent-soft)}
 
 /* ---------- software: filter by whether a package has a paper ---------- */
-/* The thumb positions reuse .pubfilter; only the hiding differs. `data-paper`
-   is present or absent rather than true/false, so these test the attribute. */
+/* Two stops, All first and selected: the list's own state is every package, and
+   the filter narrows from there. There is no inverse stop — "packages without a
+   paper" is not a thing anyone looks for. The thumb positions reuse .pubfilter;
+   only the hiding differs. `data-paper` is present or absent rather than
+   true/false, so these test the attribute. */
 #sw-all:checked ~ .h2row .pubfilter::before{transform:translateX(0)}
 #sw-yes:checked ~ .h2row .pubfilter::before{transform:translateX(100%)}
-#sw-no:checked  ~ .h2row .pubfilter::before{transform:translateX(200%)}
 #sw-all:checked ~ .h2row .pubfilter label[for="sw-all"],
-#sw-yes:checked ~ .h2row .pubfilter label[for="sw-yes"],
-#sw-no:checked  ~ .h2row .pubfilter label[for="sw-no"]{color:var(--ink)}
+#sw-yes:checked ~ .h2row .pubfilter label[for="sw-yes"]{color:var(--ink)}
 .posradio:focus-visible ~ .h2row .pubfilter{outline:2px solid var(--accent); outline-offset:2px}
 
 #sw-yes:checked ~ .lead:not([data-paper]),
-#sw-yes:checked ~ .soft .card:not([data-paper]),
-#sw-no:checked ~ .lead[data-paper],
-#sw-no:checked ~ .soft .card[data-paper]{display:none}
+#sw-yes:checked ~ .soft .card:not([data-paper]){display:none}
 /* The divider between the headliners and the tail is only meaningful when both
    are showing. */
-#sw-yes:checked ~ .tierbreak, #sw-no:checked ~ .tierbreak{display:none}
+#sw-yes:checked ~ .tierbreak{display:none}
 
 /* ---------- publications: filter by author position ---------- */
 /* Clipped rather than display:none — a display:none radio is not focusable, and

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -507,9 +507,14 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 .poslabel{font-family:var(--mono); font-size:.66rem; color:var(--ink-faint);
   letter-spacing:.02em; margin-right:.4rem; white-space:nowrap}
 
+/* inline-grid with equal auto columns, not flex. flex-basis:0 made every
+   segment the same width whatever it held, so a label needing more than its
+   share overflowed into the next one — "PAPER" wanted 48px of a 42px segment
+   and bled across the thumb. Equal grid columns size to the widest label
+   instead, so the segments fit their contents and still match the thumb. */
 .pubfilter{
-  position:relative; display:inline-flex; isolation:isolate;
-  border-radius:999px; padding:2px; background:var(--sunk);
+  position:relative; display:inline-grid; grid-auto-flow:column; grid-auto-columns:1fr;
+  isolation:isolate; border-radius:999px; padding:2px; background:var(--sunk);
 }
 /* The thumb is one segment wide, so the segments have to be equal — see the
    flex-basis on the labels. A border here as well as on the track read as two
@@ -527,9 +532,8 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 .pubfilter[data-stops="5"]{--stops:5}
 
 .pubfilter label{
-  /* basis 0 so every segment is exactly 1/N — "All" is wider than "1", and with
-     natural widths the thumb would never line up with the label it highlights. */
-  flex:1 1 0; text-align:center; min-width:2.3rem; padding:.12rem .45rem;
+  /* The grid makes the columns equal; the label only has to fill its own. */
+  text-align:center; min-width:2.2rem; padding:.12rem .45rem; white-space:nowrap;
   font-family:var(--mono); font-size:.7rem; letter-spacing:.02em;
   color:var(--ink-mute); cursor:pointer; border-radius:999px;
   transition:color .18s ease;

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -8,6 +8,7 @@ import {
   resolve,
   authorPosition,
   venueUrl,
+  softwarePaper,
   displayName,
   authors,
   venueLine,
@@ -239,5 +240,46 @@ describe('venueUrl', () => {
       .filter((p) => p.status === 'published' && (p.venue?.journal || p.venue?.booktitle))
       .filter((p) => !venueUrl(p));
     expect(missing.map((p) => p.id)).toEqual([]);
+  });
+});
+
+describe('softwarePaper', () => {
+  it('follows a package\'s ref to its paper', () => {
+    for (const id of ['unxt', 'astropy', 'trackstream', 'macro-lightning-code']) {
+      expect(softwarePaper(resolve(id)), id).toBeTruthy();
+    }
+  });
+
+  it('prefers the article at the journal over ADS or the preprint', () => {
+    // REL_ORDER ranks `ads` and `preprint` above `paper`, which is right for a
+    // trail of marks and wrong when only one link is being chosen: this used to
+    // send Astropy to ADS and macro_lightning to arXiv.
+    expect(softwarePaper(resolve('astropy')).url).toBe('https://doi.org/10.3847/1538-4357/ac7c74');
+    expect(softwarePaper(resolve('macro-lightning-code')).url).toContain('journals.aps.org');
+  });
+
+  it('falls back to what exists when the paper is not published', () => {
+    const p = softwarePaper(resolve('phasecurvefit'));
+    expect(p.status).toBe('submitted');
+    expect(p.url).toBeTruthy();
+  });
+
+  it('does not call a package published because it refs another package', () => {
+    // coordinax refs unxt — a sibling, not a paper.
+    const coordinax = resolve('coordinax');
+    expect(coordinax.refs).toContain('unxt');
+    expect(softwarePaper(coordinax)).toBeNull();
+  });
+
+  it('is null for a package with no refs at all', () => {
+    expect(softwarePaper(resolve('quax'))).toBeNull();
+    expect(softwarePaper({})).toBeNull();
+  });
+
+  it('finds exactly the packages that have one', () => {
+    const withPaper = byType('software').filter(softwarePaper).map((s) => s.id).sort();
+    expect(withPaper).toEqual(
+      ['astropy', 'macro-lightning-code', 'phasecurvefit', 'trackstream', 'unxt'],
+    );
   });
 });


### PR DESCRIPTION
Two things the Software tab could not do: show which packages are backed by a paper, and reach that paper. A package carried only its own code and docs links, so a published one looked unpublished.

```
Software                                    [ All ][ Paper ][ None ]
```

| | packages |
|---|---|
| All | 22 |
| Paper | **5** — Astropy, unxt, macro_lightning, trackstream, phasecurvefit |
| None | 17 |

The four you named, plus `phasecurvefit`. Each of those five now leads its link trail with a **paper** button.

## No schema change

`refs` already models it. What `refs` does *not* model is "paper" — `coordinax` refs `unxt`, another package — which is why the resolver checks the referent's type. That check is a test: a package must not be called published because it points at a sibling.

## One definition, not two

`paperOf` lived in `cvmodel.js` where only the PDF could see it. It now lives in `lib/data.js` as `softwarePaper`, and both the site and the PDF read it, so the two cannot disagree about which packages have a paper.

## It also picks a better link than before

Taking the first citation link sent Astropy to its **ADS record** and macro_lightning to its **arXiv preprint** — `REL_ORDER` ranks `ads` and `preprint` above `paper`, which is right for a trail of marks and wrong when only one link is being chosen. It now prefers the article at the journal:

```
Astropy          → doi.org/10.3847/1538-4357/ac7c74     (was ADS)
macro_lightning  → journals.aps.org/prd/…               (was arXiv)
unxt             → doi.org/10.21105/joss.07771
trackstream      → doi.org/10.1093/mnras/stad1166
phasecurvefit    → pyOpenSci review thread              (not published yet)
```

## Worth your attention

Because the definition is now shared, **the PDF's existing software paper icons follow the same improvement** — two of them now resolve to the journal rather than to ADS or arXiv. No links were added to the PDF and none were removed; two point somewhere better. Say the word if you would rather the PDF keep its old targets and I will gate it.

The filter is the same radio-and-sibling-selector the publications page uses, so it needs **no JavaScript**.

115 unit tests (6 new), schema, bibtex, 802 links, a11y across 9 pages, page contracts hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
