### PR TITLE
Put the CV's status pill at the end of the entry, and italicise its year

### DIFF
--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -164,7 +164,7 @@ const money = (a) => {
     ) : (
     <div class="timeline">
       {s.items.map((item) => (
-        <div class={`tl${item.type === 'publication' ? ' tl--pub' : ''}${pick ? ' tl--pick' : ''}`}
+        <div class={`tl${item.type === 'publication' ? ' tl--pub' : ''}${pick ? ' tl--pick' : ''}${item.status && item.status !== 'published' ? ' tl--unpub' : ''}`}
              id={`item-${item.id}`}>
           {pick && (
             <input type="checkbox" class="itembox" value={item.id}
@@ -193,12 +193,6 @@ const money = (a) => {
           </span>
           <span class="what">
             <strong>{item.title}</strong>
-            {/* The same pill the publications page uses. The CV page does not
-                group by status the way the PDF does, so without it a submitted
-                paper is indistinguishable from a published one. */}
-            {item.status && item.status !== 'published' && (
-              <span class="statustag">{item.status}</span>
-            )}
             {item.institution && <>, {item.institution}</>}
             {item.event && <>, {item.event}</>}
             {item.type === 'publication' && (
@@ -221,6 +215,13 @@ const money = (a) => {
             )}
             {item.declined && item.type === 'award' && <> (declined)</>}
             {item.recipient && <span class="recipient"> — to {item.recipient}</span>}
+            {/* Last on the line, after the venue. The CV page does not group by
+                status the way the PDF does, so without it a submitted paper is
+                indistinguishable from a published one — but it qualifies the
+                whole citation, not the title, so it reads at the end. */}
+            {item.status && item.status !== 'published' && (
+              <span class="statustag">{item.status}</span>
+            )}
             {detail(item).map((line, i) => (
               <span class="sub">
                 {pick && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -443,6 +443,11 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
 }
 .tl .recipient{color:var(--ink-mute); font-style:italic}
 
+/* An unpublished paper's year is the year it was submitted, not the year of
+   record — italic says the date is provisional the way the pill says the
+   status is. */
+.tl--unpub .when{font-style:italic}
+
 /* A co-author's name links to their ORCID. Eight accent-coloured names in a row
    would turn a byline into a wall of links, so it reads as text and only shows
    itself on hover and focus. */


### PR DESCRIPTION
The pill sat immediately after the title, splitting it from the byline and venue that belong with it:

```
Euclid Quick Data Release (Q1): … [SUBMITTED] — N. Starkman, J. Nibauer, … Astronomy & Astrophysics
```

It qualifies the whole citation rather than the title, so it now reads last:

```
Euclid Quick Data Release (Q1): … — N. Starkman, J. Nibauer, … Astronomy & Astrophysics [SUBMITTED]
```

Measured: the venue's right edge is 546px, the pill starts at 552px, same line.

## The year goes italic on the same entries

An unpublished paper's year is the year it was *submitted*, not the year of record. Italic says the date is provisional the way the pill says the status is.

```
unpub      font-style: italic
published  font-style: normal
```

10 entries on the complete CV carry both — the 6 submitted and 4 in-prep papers.

## Scope

The publications page is **untouched**: its pill lives in its own `.ttl` block, where "after the title" already is the end of the line. Verified the built markup there is unchanged.

The pill moves to after the venue and any trailing note, but stays ahead of the detail sub-lines, so it ends the entry's own line rather than floating below it.

109 unit tests, 802 links, a11y across 9 pages, page contracts hold — the PDF has its own pill placement and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
