### PR TITLE
Italicise the year of an unpublished paper on the publications list

### DIFF
--- a/src/components/Publication.astro
+++ b/src/components/Publication.astro
@@ -18,7 +18,8 @@ const pending = item.status !== 'published' ? item.status : null;
 // the outermost element — that is what gets hidden.
 const pos = authorPosition(item);
 ---
-<article class={brief ? 'entry--brief' : 'entry--full'} data-pos={pos ?? undefined}>
+<article class={`${brief ? 'entry--brief' : 'entry--full'}${pending ? ' entry--unpub' : ''}`}
+         data-pos={pos ?? undefined}>
   <div class="body">
     <div class="ttl">
       <a href={paper?.url ?? '#'}>{item.title}</a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -447,6 +447,9 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
    record — italic says the date is provisional the way the pill says the
    status is. */
 .tl--unpub .when{font-style:italic}
+/* Same on the publications list and the home page's short list, so a year means
+   the same thing wherever a paper is shown. */
+.entry--unpub .yr{font-style:italic}
 
 /* A co-author's name links to their ORCID. Eight accent-coloured names in a row
    would turn a byline into a wall of links, so it reads as text and only shows


### PR DESCRIPTION
A submitted paper's year is the year it was *submitted*, not the year of record, so it now reads italic on the publications list — the same thing the CV page already does, and the same reasoning as the status pill beside it.

## Verified

`/publications/` — 6 unpublished, 11 published:

```
unpubAllItalic:      true
publishedAllNormal:  true
everyUnpubHasPill:   true
```

Every italic year carries a `submitted` pill, so the two signals never disagree.

## One thing beyond the literal ask

The modifier goes on the `<article>` rather than on either `.yr` span, so it also applies to the **home page's short list** — two of its five entries. The alternative was to italicise only the full list, which would have meant the same paper showing a plain year on the home page and an italic one a click away.

Verified there too: 2 italic, 3 normal, matching status in every case.

109 unit tests, 802 links, a11y across 9 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
