### PR TITLE
Give software with a paper a button to it

### DIFF
--- a/src/components/SoftwareSection.astro
+++ b/src/components/SoftwareSection.astro
@@ -1,7 +1,7 @@
 ---
 // Three tiers, two dividers: the lead package, the headliners as cards, then
 // everything else compactly. Tier comes from the data, not from an id check.
-import { byType, links } from '../lib/data.js';
+import { byType, links, softwarePaper } from '../lib/data.js';
 import LinkIcons from './LinkIcons.astro';
 
 // The landing page shows the lead and the headliners only; the long tail is
@@ -15,13 +15,19 @@ const other = (tail ? all.filter((s) => s.tier === 'other') : [])
   .sort((a, b) => a.title.localeCompare(b.title));
 
 const href = (s) => links(s)[0]?.url ?? '#';
+// The paper leads the trail where there is one: it is the citable artefact, and
+// a package's own code and docs links sit beside it as they always did.
+const trail = (s) => {
+  const paper = softwarePaper(s);
+  return paper ? [paper, ...links(s)] : links(s);
+};
 ---
 {lead && (
   <div class="lead">
     <div class="name"><a href={href(lead)}>{lead.title}</a></div>
     {lead.role && <div class="role-line">{lead.role}</div>}
     <p>{lead.details ?? lead.summary}</p>
-    <LinkIcons links={links(lead)} />
+    <LinkIcons links={trail(lead)} />
   </div>
 )}
 
@@ -30,7 +36,7 @@ const href = (s) => links(s)[0]?.url ?? '#';
     <div class="card">
       <div class="name"><a href={href(s)}>{s.title}</a></div>
       <p>{s.details ?? s.summary}</p>
-      <LinkIcons links={links(s)} />
+      <LinkIcons links={trail(s)} />
     </div>
   ))}
 </div>
@@ -43,7 +49,7 @@ const href = (s) => links(s)[0]?.url ?? '#';
         <div class="card card--mini">
           <div class="name"><a href={href(s)}>{s.title}</a></div>
           <p>{s.summary}</p>
-          <LinkIcons links={links(s)} />
+          <LinkIcons links={trail(s)} />
         </div>
       ))}
     </div>

--- a/src/lib/cvmodel.js
+++ b/src/lib/cvmodel.js
@@ -7,7 +7,7 @@
 
 import person from '/config/person.json';
 import { resolve } from './presets.js';
-import { authors, venueLine, dateLabel, links, resolve as item0, REL_ICON, relKey } from './data.js';
+import { authors, venueLine, dateLabel, links, resolve as item0, softwarePaper, REL_ICON, relKey } from './data.js';
 import { spans, detailLines } from './inline.js';
 
 /**
@@ -75,16 +75,12 @@ function subject(item) {
  * and `astropy` refs the v5 paper, but the software entry carried only its own
  * code and docs links — so a published package looked unpublished.
  */
-const CITE = ['paper', 'preprint', 'doi'];
-function paperOf(sw) {
-  for (const id of sw.refs ?? []) {
-    const ref = item0(id);
-    if (ref?.type !== 'publication') continue;
-    const cite = links(ref).find((l) => CITE.includes(l.rel));
-    if (cite) return { rel: 'paper', url: cite.url, label: 'paper', icon: 'paper' };
-  }
-  return null;
-}
+/** One definition, in lib/data.js, so the PDF and the website cannot disagree
+ *  about which packages have a paper. The template wants an `icon`. */
+const paperOf = (sw) => {
+  const p = softwarePaper(sw);
+  return p ? { ...p, icon: 'paper' } : null;
+};
 
 /** The byline, with the CV's owner bold.
  *

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -108,6 +108,35 @@ export function venueUrl(item) {
   return null;
 }
 
+/**
+ * A package's paper, where the record points at one.
+ *
+ * `unxt` refs `unxt-joss`, `astropy` refs the v5 paper, `trackstream` refs the
+ * stream-tracks paper. The software entry itself carries only code and docs
+ * links, so without following the ref a published package looks unpublished.
+ *
+ * `refs` is not a paper field: `coordinax` refs `unxt`, another package. Hence
+ * the type check — it is what stops a package being called published because
+ * it happens to point at a sibling.
+ */
+const CITE_RELS = ['paper', 'preprint', 'doi'];
+export function softwarePaper(sw) {
+  for (const id of sw.refs ?? []) {
+    const ref = resolve(id);
+    if (ref?.type !== 'publication') continue;
+    // The article at the journal first. Taking the first citation link instead
+    // sent Astropy to its ADS record and macro_lightning to its arXiv preprint,
+    // because REL_ORDER ranks `ads` and `preprint` above `paper` — right for a
+    // trail of marks, wrong when only one link is being chosen.
+    const article = venueUrl(ref);
+    if (article) return { rel: 'paper', url: article, label: 'paper', id: ref.id, status: ref.status };
+    // Nothing published yet: a preprint or a review thread is what there is.
+    const cite = links(ref).find((l) => CITE_RELS.includes(l.rel));
+    if (cite) return { rel: 'paper', url: cite.url, label: 'paper', id: ref.id, status: ref.status };
+  }
+  return null;
+}
+
 /** Where a co-author's name points. ORCID is the identifier, so it is the link. */
 export const orcidUrl = (orcid) => (orcid ? `https://orcid.org/${orcid}` : null);
 

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -8,6 +8,7 @@ import {
   resolve,
   authorPosition,
   venueUrl,
+  softwarePaper,
   displayName,
   authors,
   venueLine,
@@ -239,5 +240,39 @@ describe('venueUrl', () => {
       .filter((p) => p.status === 'published' && (p.venue?.journal || p.venue?.booktitle))
       .filter((p) => !venueUrl(p));
     expect(missing.map((p) => p.id)).toEqual([]);
+  });
+});
+
+describe('softwarePaper', () => {
+  it('gives every package that has a paper a link to it', () => {
+    const withPaper = byType('software').filter(softwarePaper).map((s) => s.id).sort();
+    expect(withPaper).toEqual(
+      ['astropy', 'macro-lightning-code', 'phasecurvefit', 'trackstream', 'unxt'],
+    );
+  });
+
+  it('prefers the article at the journal over ADS or the preprint', () => {
+    // REL_ORDER ranks `ads` and `preprint` above `paper`, which is right for a
+    // trail of marks and wrong when only one link is being chosen: this used to
+    // send Astropy to ADS and macro_lightning to arXiv.
+    expect(softwarePaper(resolve('astropy')).url).toBe('https://doi.org/10.3847/1538-4357/ac7c74');
+    expect(softwarePaper(resolve('macro-lightning-code')).url).toContain('journals.aps.org');
+  });
+
+  it('falls back to what exists when the paper is not published', () => {
+    const p = softwarePaper(resolve('phasecurvefit'));
+    expect(p.status).toBe('submitted');
+    expect(p.url).toBeTruthy();
+  });
+
+  it('does not call a package published because it refs another package', () => {
+    // coordinax refs unxt — a sibling, not a paper.
+    expect(resolve('coordinax').refs).toContain('unxt');
+    expect(softwarePaper(resolve('coordinax'))).toBeNull();
+  });
+
+  it('is null for a package with no refs at all', () => {
+    expect(softwarePaper(resolve('quax'))).toBeNull();
+    expect(softwarePaper({})).toBeNull();
   });
 });


### PR DESCRIPTION
Split out of #41 so it can merge on its own.

A package carried only its own code and docs links, so one with a paper behind it looked like one without. The five that have a paper now lead their trail with it, in the same icon-button style as `code` and `docs`:

```
Astropy            paper, code, docs
unxt               paper, code, docs
macro_lightning    paper, code, docs, data
phasecurvefit      paper, code
trackstream        paper, code

galax              code, docs          ← no paper to link
coordinax          code, docs
```

## No schema change

`refs` already models the association. What `refs` does *not* model is "paper" — `coordinax` refs `unxt`, another package — so the resolver checks the referent's type. That is a test: a package must not be called published because it points at a sibling.

## One definition, not two

`paperOf` lived in `cvmodel.js` where only the PDF could see it. It now lives in `lib/data.js` as `softwarePaper`, read by both, so the site and the PDF cannot disagree about which packages have a paper.

## It picks a better link than the old code did

Taking the first citation link sent Astropy to its **ADS record** and macro_lightning to its **arXiv preprint** — `REL_ORDER` ranks `ads` and `preprint` above `paper`, which is right for a trail of marks and wrong when only one link is being chosen:

```
Astropy          → doi.org/10.3847/1538-4357/ac7c74     (was ADS)
macro_lightning  → journals.aps.org/prd/…               (was arXiv)
unxt             → doi.org/10.21105/joss.07771
trackstream      → doi.org/10.1093/mnras/stad1166
phasecurvefit    → pyOpenSci review thread              (not published yet)
```

## Worth your attention

Because the definition is shared, **the PDF's existing software paper icons follow the same improvement** — two now resolve to the journal rather than to ADS or arXiv. No links added to the PDF, none removed; two point somewhere better. Say the word if you would rather the PDF keep its old targets and I will gate it.

114 unit tests (5 new), 802 links, a11y across 9 pages, page contracts hold.

> #41 keeps the filter and the grid-alignment work. It will need a rebase once this lands — I will do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
