### PR TITLE
Stop the EAS talk printing Lausanne twice

### DIFF
--- a/data/2026-06-eas-26-s10-lausanne.json
+++ b/data/2026-06-eas-26-s10-lausanne.json
@@ -17,6 +17,5 @@
       "rel": "event",
       "url": "https://eas.unige.ch/EAS2026/session.jsp?id=S10"
     }
-  ],
-  "location": "Lausanne, Switzerland"
+  ]
 }


### PR DESCRIPTION
It was the only invited talk carrying a `location`, and it already had the place in its title.

## What the section does

Invited Talks name the place in the title. Eleven of the twelve carry **no** `location` field at all:

```
Marche III: Big Bang, Big Stars, Big Computers (Jesi)   trailing ''
EAS 26-S10 (Lausanne)                                   trailing 'Lausanne, Switzerland'   ← the odd one
CWRU Seminar (Cleveland)                                trailing ''
TevPA (Valencia)                                        trailing ''
DARK seminar (Copenhagen)                               trailing ''
…
```

So EAS printed Lausanne twice — once in its title, once in the right gutter — and nothing else in the section printed anything there.

This is not a rendering rule. `trailing()` shows `location` for every entry type; the other eleven talks simply have none. Conferences & Workshops **do** use it, 8 of 10, which is why the gutter looks populated there and empty here.

## Why remove the field rather than the parenthetical

Dropping `(Lausanne)` from the title would have left EAS as the only talk of twelve with a gutter location — inconsistent either way, and against the convention the other eleven already follow.

**It costs nothing for the map in #22.** That needs a location on all 65 presentations in a validated, geocodable format; today only 13 have one, in shapes like `TO, CA` and `GIT, USA` that do not geocode. #22 already scopes that backfill.

## Verified

```
invited talks with a trailing value:  0 of 12   (was 1)
conferences still showing location:   8 of 10   (unchanged)
```

Page contracts hold, 115 unit tests, schema, bibtex, 802 links, a11y across 9 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
