### PR TITLE
Software: the paper icon instead of the word, in both places

### DIFF
--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -4,7 +4,8 @@
 import CvHeader from './CvHeader.astro';
 import { presetNames, preset, resolve, sectionIndex } from '../lib/presets.js';
 import { dateLabel, authors, venueLine,
-  venueUrl, links, REL_ICON, relKey, authorPosition } from '../lib/data.js';
+  venueUrl, links, REL_ICON, relKey, authorPosition,
+  softwarePaper } from '../lib/data.js';
 import { spans, detailLines } from '../lib/inline.js';
 import LinkIcons from './LinkIcons.astro';
 
@@ -14,6 +15,13 @@ import LinkIcons from './LinkIcons.astro';
  * them, is a button that does nothing — with positions 1, 2 and 4 that leaves
  * 1 and 2, and None/All bracket them.
  */
+// Worth offering only when it splits the section: if every package has a
+// paper, or none does, the button would just be a slower "All".
+function paperCut(section) {
+  const withPaper = section.items.filter(softwarePaper).length;
+  return withPaper > 0 && withPaper < section.items.length;
+}
+
 function posStops(section) {
   const positions = section.items
     .filter((i) => i.type === 'publication')
@@ -109,6 +117,18 @@ const money = (a) => {
           <button type="button" class="posbtn" data-possel="all">All</button>
         </span>
       )}
+      {/* Software's version of the same idea. Two stops rather than five,
+          because the only cut worth making here is "has a paper", and shown
+          only when it would actually cut something. */}
+      {selectable && s.id === 'software' && paperCut(s) && (
+        <span class="possel" role="group" aria-label="Select software by whether it has a paper">
+          <button type="button" class="posbtn" data-papersel="all">All</button>
+          <button type="button" class="posbtn posbtn--icon" data-papersel="yes"
+                  aria-label="Only software with a paper" title="Only software with a paper">
+            <svg class="ico" aria-hidden="true" focusable="false"><use href="#i-paper" /></svg>
+          </button>
+        </span>
+      )}
       {selectable && s.items.some((i) => detail(i).length > 0) && (
         <label class="subgrouplab">
           <input type="checkbox" class="subgroup" checked={level === 'full'}
@@ -149,6 +169,7 @@ const money = (a) => {
             <div class="name">
               {pick && (
                 <input type="checkbox" class="itembox" value={item.id}
+                       data-paper={softwarePaper(item) ? 'yes' : undefined}
                        checked={isPicked(item.id)}
                        aria-label={`Include ${item.title}`} />
               )}

--- a/src/pages/cv/builder.astro
+++ b/src/pages/cv/builder.astro
@@ -157,6 +157,20 @@ const site = buildInfo();
           : want === 'all' ? `All ${on} publications selected.`
           : `${on} publications with author position ${want} or better.`);
       }
+      if (t.dataset.papersel !== undefined) {
+        // Scoped to its own section, exactly as the position cut is.
+        const group = t.closest('.pickgroup');
+        const all = t.dataset.papersel === 'all';
+        let on = 0;
+        for (const b of group.querySelectorAll('.itembox')) {
+          const keep = all || b.dataset.paper !== undefined;
+          b.checked = keep;
+          if (keep) on += 1;
+        }
+        recount();
+        status(all ? `All ${on} packages selected.`
+          : `${on} packages with a paper.`);
+      }
       if (t.dataset.preset) {
         const ids = new Set(MEMBERSHIP[t.dataset.preset] ?? []);
         boxes().forEach((b) => (b.checked = ids.has(b.value)));

--- a/src/pages/software.astro
+++ b/src/pages/software.astro
@@ -13,15 +13,21 @@ const withPaper = all.filter(softwarePaper).length;
         {/* Direct children of .wrap and ahead of the cards, so the filter is a
             plain sibling selector on :checked — no JavaScript. Clipped rather
             than display:none so they stay focusable and arrow-navigable. */}
-        <input type="radio" name="sw" id="sw-all" class="posradio" checked />
-        <input type="radio" name="sw" id="sw-yes" class="posradio" />
+        <input type="radio" name="sw" id="sw-all" class="posradio" checked
+               aria-label={`All ${all.length} packages`} />
+        {/* The label is a glyph, so the radio carries its own name — a label
+            holding nothing but an aria-hidden icon would leave it unnamed. */}
+        <input type="radio" name="sw" id="sw-yes" class="posradio"
+               aria-label={`Only the ${withPaper} packages with a paper`} />
 
         <div class="h2row">
           <h2>Software</h2>
           <span class="more">
             <span class="pubfilter" data-stops="2">
               <label for="sw-all" title={`All ${all.length} packages`}>All</label>
-              <label for="sw-yes" title={`${withPaper} packages with a paper`}>Paper</label>
+              <label for="sw-yes" title={`${withPaper} packages with a paper`}>
+                <svg class="ico" aria-hidden="true" focusable="false"><use href="#i-paper" /></svg>
+              </label>
             </span>
           </span>
         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -534,6 +534,10 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
   padding:.05rem .4rem; cursor:pointer; line-height:1.5;
 }
 .posbtn:hover{color:var(--accent); border-color:var(--accent-line); background:var(--accent-soft)}
+/* A glyph rather than a word, so the padding is even and the box is square-ish
+   instead of stretched by uppercase letter-spacing that no longer applies. */
+.posbtn--icon{display:inline-flex; align-items:center; padding:.05rem .35rem; letter-spacing:0}
+.posbtn--icon .ico{width:11px; height:11px; fill:currentColor; display:block}
 
 /* ---------- software: filter by whether a package has a paper ---------- */
 /* Two stops, All first and selected: the list's own state is every package, and
@@ -601,6 +605,11 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
   transition:color .18s ease;
 }
 .pubfilter label:hover{color:var(--ink)}
+/* An icon stop. Centred in its segment and given the line-height of the text
+   stops beside it, so the two segments are the same height and the thumb does
+   not have to grow to cover one of them. */
+.pubfilter label:has(> .ico){display:flex; align-items:center; justify-content:center}
+.pubfilter label .ico{width:13px; height:13px; fill:currentColor; display:block}
 
 /* Where the thumb sits, and which label is lit. "All" is first, so the stops
    read left to right as no-limit, then tightening. */


### PR DESCRIPTION
Two halves of the same idea.

## Software tab: ALL | PAPER → ALL | 📄

The filter's second stop said **PAPER** — the only word in a row of controls that everywhere else draws a glyph, and the same `#i-paper` mark already sits on every card that has one.

A label containing nothing but an `aria-hidden` icon leaves its radio unnamed, so both radios now carry their own `aria-label`, matching what the tooltips already said:

- `sw-all` → "All 24 packages"
- `sw-yes` → "Only the 5 packages with a paper"

Both segments stay 35.2 × 21.2px, so the thumb still covers either one exactly; the icon is 13px, centred.

## CV builder: the same cut for Software

Publications has had the author-position cut for a while (`None | 1 | 2 | All`). Software gets the same control with one stop, since the only cut worth making here is whether there is a paper:

```
All | 📄
```

Scoped to its own `.pickgroup` exactly as the position cut is, and rendered only when it would actually divide the section — if every package had a paper, or none did, the button would just be a slower "All". Confirmed: the selector appears on `publications` (position) and `software` (paper), nowhere else.

Driven in the browser:

| action | result |
|---|---|
| 📄 | 5 of 24 checked — `astropy`, `unxt`, `macro-lightning-code`, `phasecurvefit`, `trackstream` |
| All | 24 of 24 |
| either | Publications' 17 selections untouched |

Status line reports "5 packages with a paper." / "All 24 packages selected.", like the position cut does.

## Checks

- 122 unit tests, schema, bibtex, a11y, 807 links across 9 pages
- both buttons 18px tall, icon 11px, hidden until the heading is hovered — same as the publications selector
- no horizontal overflow

## One thing I found and did not touch

While verifying, the segmented control's **thumb does not move and the lit label does not change** when the filter is switched — the card filtering works, but the indicator stays on "All". I checked this against `main` before my change and it behaves identically there, so it is pre-existing and not from this PR. It is most likely an artifact of the headless browser I am driving (it appears not to invalidate the `::before` transform on a sibling `:checked` change) rather than something you would see in a real browser — worth a glance next time you have the page open, and I did not chase it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
