### PR TITLE
CV builder: a style menu, and a mark-free Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,41 @@ npm test           # schema + bibtex + accessible-name checks; CI runs this on e
 npm run build:all  # the site, then the four CV PDFs (needs typst)
 ```
 
+## The CV
+
+The four pre-built PDFs and the in-browser builder at `/cv/builder/` compile the
+same `cv/cv.typ` from the same render model, so the PDF and the site cannot
+disagree about what a preset contains. Under CI the Typst CLI reads `cv.json`
+off disk; in the browser typst.ts is handed the same filename through its
+virtual filesystem. Nothing forks.
+
+### Styles
+
+The builder adds a style menu beside **Compile PDF**:
+
+| style | what it is |
+|---|---|
+| **Default** | what the pre-built PDFs are. Font Awesome and Academicons marks on links, section headings and the contact block. |
+| **Default - 🎨** | the same CV with none of the marks. Where a glyph stood alone the word takes its place — a resource trail reads `code, docs` rather than two icons — and the PDF embeds no icon fonts at all. |
+
+A style is one key on `cv.json`:
+
+```json
+{ "style": "plain" }
+```
+
+read by `cv.typ` as `cv.at("style", default: "default")`. **Only the builder
+sets it.** The CLI never writes it, so every pre-built PDF is the default and
+the one- and two-page contracts cannot be affected by a style. (Both hold at
+one and two pages in either style regardless, which is worth knowing: words are
+wider than glyphs.)
+
+Adding a style is a branch in `cv.typ` behind that key plus an `<option>` in
+`src/pages/cv/builder.astro` — not a second template. Call sites that pair a
+mark with words go through one `marked()` helper, so the styles cannot drift
+apart; only a mark standing *alone* needs a deliberate fallback, or it compiles
+to an empty link.
+
 ## Deployment
 
 GitHub Pages via Actions (`.github/workflows/deploy.yml`), not a branch deploy:

--- a/cv/cv.typ
+++ b/cv/cv.typ
@@ -24,6 +24,13 @@
 // the top and two-thirds empty at the bottom.
 #let tight = cv.preset == "1page"
 
+// Which pre-built style. "default" draws the marks; "plain" spells them out in
+// words instead, for anywhere a row of glyphs is unwelcome — a plain-text ATS,
+// a printer that renders symbol fonts badly, or simply a preference. Only the
+// browser builder sets it, so the CLI PDFs are always the default and their
+// page-count contracts are unaffected.
+#let plain = cv.at("style", default: "default") == "plain"
+
 #let ink = rgb("#111111")
 #let accent = rgb("#003399") // linkcolour: rgb(0, 0.2, 0.6)
 #let faint = rgb("#808080") // \grayhref: gray 0.5
@@ -129,6 +136,13 @@
   icon(name, size: size, fill: fill),
 )
 
+// A mark with words beside it — or, in the plain style, the words on their own.
+// Every call site that pairs the two goes through this, so switching styles is
+// one branch rather than one per mark.
+#let marked(name, body, size: 1em, fill: accent) = if plain { body } else {
+  [#icon(name, size: size, fill: fill) #body]
+}
+
 // ── header ────────────────────────────────────────────────────────────────
 // Four columns across the full measure rather than five centred lines: a QR to
 // the website, the portrait, who he is, and how to reach him. Same information,
@@ -141,7 +155,8 @@
   let service = lower(pr.at("service", default: pr.label))
   let mark = service
   let label = if service == "orcid" { p.orcid } else { pr.label }
-  link(pr.url, [#icon(mark, size: 0.9em, fill: if service == "orcid" { orcid } else { accent }) #label])
+  link(pr.url, marked(mark, label, size: 0.9em,
+                      fill: if service == "orcid" { orcid } else { accent }))
 }).join(h(3pt))
 
 // Who he is. Sets the height the contact column matches.
@@ -160,9 +175,9 @@
 // transcription data — street number, postcode, ORCID iD — so it stays lining.
 #let contactlines = p.addressLines.map(l => text(size: 8.9pt, l)) + (
   text(size: 8.9pt)[
-    #link("mailto:" + p.email)[#icon("email", size: 0.9em) #p.email]
+    #link("mailto:" + p.email)[#marked("email", p.email, size: 0.9em)]
     #h(5pt)
-    #link(p.websiteUrl)[#icon("globe", size: 0.9em) #p.website]
+    #link(p.websiteUrl)[#marked("globe", p.website, size: 0.9em)]
   ],
   text(size: 8.2pt)[#profiles],
 )
@@ -215,7 +230,7 @@
   block(breakable: false, sticky: true)[
     #set par(justify: false, spacing: 0pt)
     #text(size: 15.6pt)[
-      #if mark != none [#icon(mark, size: 0.95em, fill: ink) #h(2pt)]
+      #if mark != none and not plain [#icon(mark, size: 0.95em, fill: ink) #h(2pt)]
       #smallcaps(title)
     ]
     #v(4.5pt)
@@ -247,7 +262,13 @@
 // The resource trail: marks, not words, so it costs the end of a line instead
 // of a line of its own.
 #let trail(links, tint: accent, size: 1em) = {
-  links.map(l => iconlink(l.url, l.icon, size: size, fill: tint)).join(h(3pt))
+  if plain {
+    // Nothing left to carry the meaning, so the words do it — and they are the
+    // words the model already holds: code, docs, data, repo.
+    links.map(l => link(l.url, text(size: size * 0.86, fill: tint, l.label))).join([, ])
+  } else {
+    links.map(l => iconlink(l.url, l.icon, size: size, fill: tint)).join(h(3pt))
+  }
 }
 
 // ── one entry ─────────────────────────────────────────────────────────────
@@ -307,9 +328,11 @@
       let rest = it.links.filter(l => not (l.icon in ("ads", "arxiv", "paper", "doi")))
       let cited = cite
         .map(l => if l.label == l.rel {
-          link(l.url, icon(l.icon, size: 0.9em))
+          // The label is the bare rel — "paper", "repo" — which is a word the
+          // mark was standing in for, so it serves when the mark is gone.
+          link(l.url, if plain { text(size: 0.9em, l.label) } else { icon(l.icon, size: 0.9em) })
         } else {
-          link(l.url, [#icon(l.icon, size: 0.9em) #lnum(l.label)])
+          link(l.url, marked(l.icon, lnum(l.label), size: 0.9em))
         })
         .join(h(5pt))
       if cite.len() > 0 [ #cited]

--- a/src/pages/cv/builder.astro
+++ b/src/pages/cv/builder.astro
@@ -45,6 +45,13 @@ const site = buildInfo();
         </div>
 
         <div class="builderbar builderbar--go">
+          {/* Left of Compile, because it is a choice about the thing being
+              compiled rather than a second action. */}
+          <label class="bl" for="style">Style</label>
+          <select class="btn btn--sel" id="style">
+            <option value="default">Default</option>
+            <option value="plain">Default - 🎨</option>
+          </select>
           <button class="btn btn--go" type="button" id="build">Compile PDF</button>
           <a class="btn" id="download" download="starkman-cv-custom.pdf" hidden>Download</a>
           <span class="status" id="status">The compiler is ~10 MB and loads on first use.</span>
@@ -324,6 +331,21 @@ const site = buildInfo();
       return typst;
     }
 
+    // A compiled PDF belongs to the style it was compiled with. Changing the
+    // menu retires it — otherwise Download keeps handing over a file that no
+    // longer matches what the menu says, and the preview keeps showing it.
+    $('style').addEventListener('change', () => {
+      const dl = $('download');
+      if (dl.hidden) return;
+      URL.revokeObjectURL(dl.href);
+      dl.hidden = true;
+      dl.removeAttribute('href');
+      const frame = $('preview');
+      frame.hidden = true;
+      frame.removeAttribute('src');
+      status('Style changed — compile again.');
+    });
+
     $('build').addEventListener('click', async () => {
       const chosen = new Set(boxes().filter((b) => b.checked).map((b) => b.value));
       if (!chosen.size) return status('Nothing selected.');
@@ -346,6 +368,9 @@ const site = buildInfo();
           const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
           await t.mapShadow(`/assets/${path.split('/').pop()}`, bytes);
         }
+        // The template reads this; absent, it compiles the default. The CLI
+        // never writes it, so the pre-built PDFs cannot drift from this menu.
+        model.style = $('style').value;
         await t.mapShadow('/cv.json', new TextEncoder().encode(JSON.stringify(model)));
         const pdf = await t.pdf({ mainFilePath: '/cv.typ' });
 
@@ -358,6 +383,8 @@ const site = buildInfo();
         frame.src = url;
         $('download').hidden = false;
         $('download').href = url;
+        $('download').download = model.style === 'default'
+          ? 'starkman-cv-custom.pdf' : `starkman-cv-custom-${model.style}.pdf`;
 
         const kb = Math.round(pdf.length / 1024);
         status(`Built ${chosen.size} entries · ${kb} KB.`);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -344,6 +344,20 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
   font-variant-numeric:tabular-nums}
 .btn--go{background:var(--ink); color:var(--ground); border-color:var(--ink);
   font-size:.75rem; padding:.35rem .8rem}
+
+/* The style menu. A real <select>, so it gets the platform's own popup and
+   keyboard handling for free; .btn gives it the shape of the buttons beside it
+   and this only undoes the parts a select does not want. */
+.btn--sel{
+  appearance:none; cursor:pointer;
+  /* Matched to .btn--go's height rather than .btn's: those two sit side by side
+     and a control strip of two heights reads as a mistake. */
+  padding:.35rem 1.4rem .35rem .55rem;
+  background-image:linear-gradient(45deg,transparent 50%,currentColor 50%),
+                   linear-gradient(135deg,currentColor 50%,transparent 50%);
+  background-position:right .62rem center, right .45rem center;
+  background-size:4px 4px, 4px 4px; background-repeat:no-repeat;
+}
 .btn--go:hover{background:var(--ink); color:var(--ground); border-color:var(--ink)}
 .btn--go:disabled{opacity:.5; cursor:progress}
 .status{font-family:var(--mono); font-size:.7rem; color:var(--ink-mute)}


### PR DESCRIPTION
A dropdown left of **Compile PDF** — left, because it is a choice about the thing being compiled rather than a second action to take.

| | |
|---|---|
| **Default** | what the pre-built PDFs are |
| **Default - 🎨** | the same CV with none of the marks |

## Not a second template

`cv.typ` reads one more key off `cv.json`:

```typst
#let plain = cv.at("style", default: "default") == "plain"
```

and every call site that pairs a mark with words goes through one helper:

```typst
#let marked(name, body, size: 1em, fill: accent) = if plain { body } else {
  [#icon(name, size: size, fill: fill) #body]
}
```

So there is nothing to keep in sync. The interesting cases are the three places a mark stood **alone** — the resource trail, and the citation links whose label is the bare rel. Dropping the glyph there would have left an empty link, so the plain style prints the word the model already holds:

```
default:  unxt  ￼ ￼            (glyphs, which extract as nothing)
plain:    unxt paper, docs
```

## Verified rather than assumed

**The default is unchanged.** Compiled `complete` with the template before and after this change; extracted text is byte-identical. The refactor is a true no-op for the existing style.

**The plain style really has no marks** — not "styled differently", *absent*. Embedded fonts:

| | fonts in the PDF |
|---|---|
| default | NewCM ×4, **FontAwesome5Free-Solid, FontAwesome5Brands, Academicons** |
| plain | NewCM ×4 |

**Page counts hold in both styles**, which was not a given since words are wider than glyphs:

| preset | default | plain |
|---|---|---|
| 1page | 1 | 1 |
| 2page | 2 | 2 |
| np | 5 | 5 |
| complete | 8 | 8 |

The CLI never writes the key, so every pre-built PDF is the default regardless — the contracts were never at risk, but it is better that plain holds too.

**Both compile in the browser**, not just under the CLI. That is the path that has silently diverged before, so I drove it: `plain` → 288 KB, no FontAwesome or Academicons in the blob, downloads as `starkman-cv-custom-plain.pdf`; `default` → 322 KB, both icon fonts present, `starkman-cv-custom.pdf`.

## Changing the style retires the compiled PDF

Download and the preview belong to the style they were built with, so changing the menu hides both, revokes the blob and says "Style changed — compile again." A Download button that hands over a file the menu no longer describes is worse than no button.

Confirmed in the browser: after a compile both are visible with a live `blob:` href; after switching the menu both are hidden with `href`/`src` removed.

## Also

- The `<select>` is a real one, so it gets the platform popup and keyboard handling for free; `.btn--sel` only undoes what a select does not want, and matches `.btn--go`'s height so the two adjacent controls are not two different sizes.

## Checks

122 unit tests, schema, a11y, 807 links, and `build:pdf` — 1page still 1 page, 2page still 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
