### PR TITLE
Stop the style menu's arrow flying off on hover

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,9 +130,16 @@ h2{
 .btn{
   font-family:var(--mono); font-size:.7rem; letter-spacing:.04em;
   color:var(--ink-mute); background:var(--surface); border:1px solid var(--rule);
-  border-radius:.3rem; padding:.24rem .55rem; transition:.15s;
+  border-radius:.3rem; padding:.24rem .55rem;
+  /* Named properties, not `all`. A button that draws anything with a
+     background-image — the style menu's arrow does — would otherwise animate
+     its geometry on hover as well as its colour. */
+  transition:color .15s, background-color .15s, border-color .15s;
 }
-.btn:hover{color:var(--accent); border-color:var(--accent-line); background:var(--accent-soft); text-decoration:none}
+/* background-COLOR, not the shorthand: `background` resets background-image to
+   none and background-position to 0 0, which wiped the style menu's arrow and
+   — being transitioned — flew it to the corner on the way out. */
+.btn:hover{color:var(--accent); border-color:var(--accent-line); background-color:var(--accent-soft); text-decoration:none}
 
 /* --- brief entries: landing page only. Flex with a right-hand gutter for the
    year and the paper button — as a grid row-span the gutter's surplus height
@@ -358,7 +365,7 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
   background-position:right .62rem center, right .45rem center;
   background-size:4px 4px, 4px 4px; background-repeat:no-repeat;
 }
-.btn--go:hover{background:var(--ink); color:var(--ground); border-color:var(--ink)}
+.btn--go:hover{background-color:var(--ink); color:var(--ground); border-color:var(--ink)}
 .btn--go:disabled{opacity:.5; cursor:progress}
 .status{font-family:var(--mono); font-size:.7rem; color:var(--ink-mute)}
 #preview{width:100%; height:min(78vh,900px); border:1px solid var(--rule);


### PR DESCRIPTION
Follow-up to #49. Inspected first — the cause is two lines apart from each other.

## What was happening

```css
.btn        { background:var(--surface); transition:.15s; }   /* = transition-property: all */
.btn:hover  { background:var(--accent-soft); }                /* the SHORTHAND */
.btn--sel   { background-image:<two gradients>; background-position:right .62rem center, right .45rem center; }
```

The arrow is drawn with two `linear-gradient`s. `background` is a **shorthand**, so `.btn:hover` did not just change the colour — it reset `background-image` to `none` and `background-position` to `0% 0%`. And since `.btn` transitioned **`all`**, the position change was animated. The arrow slid to the corner and disappeared: the "weird flying animation".

Measured in the browser rather than reasoned about:

| | `background-image` | `background-position` |
|---|---|---|
| at rest | two gradients | `calc(100% - 9.92px) 50%, calc(100% - 7.2px) 50%` |
| with the hover shorthand applied | **`none`** | **collapses to one value** |

`transition-property` was `all`, and `background-position` is animatable — so both halves of the arrow interpolated to a single position on the way to nothing.

## The fix

Both changes narrow something rather than add anything:

1. **`.btn:hover` and `.btn--go:hover` set `background-color`**, not the shorthand. A button's `background-image` is no longer collateral damage from a colour change.
2. **`.btn` names its transitions** — `color, background-color, border-color` — instead of `all`. `transition:.15s` meant every animatable property, which is how a colour hover ended up animating geometry. Now no button can do that by accident.

Either change alone stops the flight; together they also stop the next one.

## After

| | |
|---|---|
| arrow survives hover | yes — `background-image` unchanged |
| `background-position` on hover | identical to at rest |
| `transition-property` | `color, background-color, border-color` |

a11y and 807 links pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
