### PR TITLE
Say "Save Selection" in the condensed bar

### DIFF
--- a/src/components/CvHeader.astro
+++ b/src/components/CvHeader.astro
@@ -16,11 +16,11 @@ const onBuilder = current === 'builder';
     <span class="more">
       {onBuilder
         /* Jumping to a fixed-length CV mid-build would discard the selection
-           without warning, so the condensed bar offers Save in that slot
+           without warning, so the condensed bar offers Save Selection in that slot
            instead. The lengths stay in the heading row, which means leaving
            this page is something you scroll back up to do deliberately. */
         ? <span class="cvtoggle cvtoggle--main">
-            <button class="btn" type="button" id="savebar" tabindex="-1">Save</button>
+            <button class="btn" type="button" id="savebar" tabindex="-1">Save Selection</button>
           </span>
         : <span class="cvtoggle cvtoggle--main">
             {presetNames.map((n) => (


### PR DESCRIPTION
`Save` → `Save Selection` in the CV builder's sticky bar.

It sits next to **Download PDF**, which made "Save" ambiguous — it reads as saving the PDF. It saves the tick-boxes: the selection that a mid-build navigation would otherwise discard, which is the whole reason that button is in that slot.

Checked it does not disturb the bar: 120px wide, no wrapping, no bar or page overflow at desktop or at the narrowest width this browser will give me (474px — the pane clamps there rather than going to 375). a11y passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
