### PR TITLE
Add the 2022 ADASS software prize

### DIFF
--- a/data/2021-astropy-coordinator-developer.json
+++ b/data/2021-astropy-coordinator-developer.json
@@ -17,7 +17,7 @@
     "2025–2028: Coordination Committee (executive committee).",
     "2025–2026: Strategic Planning and Organizing Committee.",
     "Funding: [Astropy Cycle III — Cosmology](item:astropy-cycle-iii-funding-grant) and [Quantity 2.0](item:astropy-cycle-iii-funding-grants).",
-    "Team awards: [2025 AAS Lancelot M. Berkeley–New York Community Trust Prize](item:astropy-berkeley-prize) and the [2023 IOP Publishing Top Cited Paper Award](item:astropy-iop-top-cited-paper-award)."
+    "Team awards: [2025 AAS Lancelot M. Berkeley–New York Community Trust Prize](item:astropy-berkeley-prize), the [2023 IOP Publishing Top Cited Paper Award](item:astropy-iop-top-cited-paper-award) and the [2022 ADASS Prize for an Outstanding Contribution to Astronomical Software](item:astropy-adass-software-prize)."
   ],
   "institution": "Astropy",
   "links": [
@@ -31,6 +31,7 @@
     "astropy-cycle-iii-funding-grant",
     "astropy-cycle-iii-funding-grants",
     "astropy-berkeley-prize",
-    "astropy-iop-top-cited-paper-award"
+    "astropy-iop-top-cited-paper-award",
+    "astropy-adass-software-prize"
   ]
 }

--- a/data/2021-astropy.json
+++ b/data/2021-astropy.json
@@ -14,7 +14,7 @@
   },
   "title": "Astropy",
   "summary": "Astronomy in Python",
-  "details": "The community core package for astronomy in Python. The collaboration received the 2025 AAS Lancelot M. Berkeley Prize and a 2023 IOP Publishing Top Cited Paper Award.",
+  "details": "The community core package for astronomy in Python. The collaboration received the 2025 AAS Lancelot M. Berkeley Prize, a 2023 IOP Publishing Top Cited Paper Award and the 2022 ADASS software prize.",
   "repo": "astropy/astropy",
   "role": "Core developer · Coordination Committee · Strategic Planning",
   "links": [

--- a/data/2022-astropy-adass-software-prize.json
+++ b/data/2022-astropy-adass-software-prize.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../schema/item.schema.json",
+  "id": "astropy-adass-software-prize",
+  "type": "award",
+  "tier": "major",
+  "cvs": [
+    "np"
+  ],
+  "date": {
+    "start": "2022"
+  },
+  "title": "ADASS Prize for an Outstanding Contribution to Astronomical Software",
+  "recipient": "the Astropy Project",
+  "details": "Team award, as a core developer of [Astropy](item:astropy).",
+  "funder": "Astronomical Data Analysis Software and Systems",
+  "links": [
+    {
+      "rel": "homepage",
+      "url": "https://www.adass.org/softwareprize.html"
+    }
+  ],
+  "refs": [
+    "astropy"
+  ],
+  "tags": [
+    "astropy"
+  ]
+}


### PR DESCRIPTION
> "add the ADASS Software Prize, with the Astropy Project (2022) to Astropy as well. Look it up and find it."

## What the source says

[adass.org/softwareprize.html](https://www.adass.org/softwareprize.html), which is also the link Astropy's own awards list points at:

| | |
|---|---|
| full name | **ADASS Prize for an Outstanding Contribution to Astronomical Software** |
| awarded by | the Program Organizing Committee of the ADASS conference series |
| 2022 | The Astropy Project |

The citation recognises Astropy's contribution to the astronomical software community and its impact on many astronomy projects.

## The date is the year, deliberately

ADASS lists the prize by year with no date attached, and ADASS XXXII — where it was presented — ran **31 October to 4 November 2022**, straddling the month boundary. So `"start": "2022"`.

The Berkeley prize is `2025-01` and the IOP award `2023-11` because their sources give exact dates. This one's does not, and a month here would be a guess wearing the costume of precision.

## Placement

Same treatment you asked for on the IOP award: `cvs: ["np"]` — NP and Complete, not 2P or 1P — and a third entry on the Astropy role's team-award line, which lands in exactly those two CVs because detail lines only render at `detail: full`.

Verified across all four presets: item and line present in Complete and NP, absent from 2P and 1P.

His Astropy core-developer role starts in 2021, so 2022 falls inside it — the team-award claim holds.

## Checks

Schema, 122 unit tests, 815 links, and `build:pdf` still holds 1page at one page and 2page at two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
