### PR TITLE
Separate the builder's first section from the controls

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -684,6 +684,11 @@ footer .wrap{padding-block:1.5rem; display:flex; justify-content:space-between; 
   margin:1.6rem 0 .3rem; padding-bottom:.3rem; border-bottom:1px solid var(--rule);
 }
 .cvsec--first .cvsechead{margin-top:1rem}
+/* In the builder the first heading follows a row of controls rather than the
+   page heading, and 1rem is the same gap the list uses internally — so the
+   content ran on from the buttons instead of starting after them. #tree is the
+   builder's own wrapper, so the read-only CV pages keep their spacing. */
+#tree .cvsec--first .cvsechead{margin-top:2rem}
 /* A collapsed section: the whole head is the control, so it takes the pointer
    and the caret, and the count says what is behind it. */
 summary.cvsechead{cursor:pointer; list-style:none}


### PR DESCRIPTION
> "in CV | BUILD add a bit more whitespace separating the first content block Education, etc from the previous buttons and settings"

Measured first: the gap between the bottom of the compile row and the top of the **Education** heading was **16px**, from `.cvsec--first .cvsechead{margin-top:1rem}`. That is the same 1rem the list uses between its own parts, which is why the content read as a continuation of the controls rather than the start of a new thing.

Now **32px**.

## Scoped to the builder

`.cvsec--first` is shared with the read-only `/cv/` pages, where that first heading follows the *page heading* rather than a row of controls and 16px is right. So the new rule hangs off `#tree` — the builder's own wrapper, and the only place it exists.

Confirmed both ways:

| page | `margin-top` on the first heading |
|---|---|
| `/cv/builder/` | **32px** |
| `/cv/` | 16px, unchanged |

a11y and 811 links pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
