### PR TITLE
Retire the compiled PDF when the selection changes

### DIFF
--- a/src/pages/cv/builder.astro
+++ b/src/pages/cv/builder.astro
@@ -94,6 +94,7 @@ const site = buildInfo();
     /** An unticked line greys out in place, so the page keeps showing what it
      *  is about to compile rather than describing it. */
     const applyDetail = () => {
+      retire('Selection changed — compile again.');
       for (const b of subs()) b.closest('.sub').classList.toggle('is-off', !b.checked);
       // a section's control reflects its lines rather than driving them
       for (const g of document.querySelectorAll('.pickgroup')) {
@@ -107,7 +108,25 @@ const site = buildInfo();
     };
     const status = (msg) => { $('status').textContent = msg; };
 
+    /** A compiled PDF is only good for the selection, the detail and the style
+     *  it was compiled from. Anything that changes one of those retires it:
+     *  otherwise Download hands over a file that no longer matches the page,
+     *  and the preview goes on showing it. Silent when there is nothing
+     *  compiled, which is why the init call below costs nothing. */
+    const retire = (why) => {
+      const dl = $('download');
+      if (dl.hidden) return;
+      URL.revokeObjectURL(dl.href);
+      dl.hidden = true;
+      dl.removeAttribute('href');
+      const frame = $('preview');
+      frame.hidden = true;
+      frame.removeAttribute('src');
+      status(why);
+    };
+
     const recount = () => {
+      retire('Selection changed — compile again.');
       const on = boxes().filter((b) => b.checked).length;
       $('count').textContent = `${on} / ${boxes().length}`;
       // a group box reflects its children rather than driving them
@@ -334,17 +353,7 @@ const site = buildInfo();
     // A compiled PDF belongs to the style it was compiled with. Changing the
     // menu retires it — otherwise Download keeps handing over a file that no
     // longer matches what the menu says, and the preview keeps showing it.
-    $('style').addEventListener('change', () => {
-      const dl = $('download');
-      if (dl.hidden) return;
-      URL.revokeObjectURL(dl.href);
-      dl.hidden = true;
-      dl.removeAttribute('href');
-      const frame = $('preview');
-      frame.hidden = true;
-      frame.removeAttribute('src');
-      status('Style changed — compile again.');
-    });
+    $('style').addEventListener('change', () => retire('Style changed — compile again.'));
 
     $('build').addEventListener('click', async () => {
       const chosen = new Set(boxes().filter((b) => b.checked).map((b) => b.value));


### PR DESCRIPTION
Ticking a box left **Download** offering the previous PDF and the preview showing it, with nothing on the page admitting the two had parted company. Same failure the style menu already guarded against in #49.

## Where it hooks in

Not the checkbox handler — `recount()` and `applyDetail()`. Those are what every path that changes the output already funnels through, so one place covers all of them, and the next control added gets it for free.

Verified each path individually rather than assuming the funnel:

| what changed | retired | status afterwards |
|---|---|---|
| item checkbox | yes | Selection changed — compile again. |
| detail line | yes | Selection changed — compile again. |
| section box | yes | Selection changed — compile again. |
| detail group box | yes | Selection changed — compile again. |
| preset button | yes | *Selection set from Complete.* |
| None | yes | Selection changed — compile again. |
| author-position selector | yes | *Publications cleared.* |
| paper selector | yes | *All 24 packages selected.* |
| style menu | yes | Style changed — compile again. |

Loading a saved selection goes through the same two functions, so it is covered by construction.

Note the italicised rows: buttons that report their own result keep it. `status()` runs *after* `recount()` in those handlers, so "Selection set from Complete." is not clobbered by a generic line — you still learn what the button did, and the Download button being gone says the rest.

## Two things that could have gone wrong, and did not

**The compile itself must not trigger it.** If anything called `recount()` after a successful build, Download would vanish the instant it appeared. It does not — confirmed by compiling and watching Download stay put.

**It has to be silent at init.** `recount()` and `applyDetail()` both run on page load; `retire()` returns immediately when nothing is compiled, so that costs nothing and shows no message.

Full cycle end to end: compile → *Built 97 entries* → untick one → Download and preview gone, message shown → compile → **Built 96 entries**, Download back with a fresh blob. The count moving 97 → 96 is the proof the recompile used the new selection.

122 unit tests, a11y, 811 links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
