### PR TITLE
Carry the style in a saved selection

### DIFF
--- a/src/lib/selection.js
+++ b/src/lib/selection.js
@@ -1,7 +1,7 @@
 // The saved-selection file for the CV builder.
 //
 // A selection is a list of entry ids plus, per entry, which of its detail lines
-// are kept. That only means something against a particular version of the
+// are kept, and the style it was meant to be compiled in. That only means something against a particular version of the
 // database, so the file records the commit the site was built from: if the ids
 // no longer resolve, `git checkout <commit>` and a local build gets them back.
 //
@@ -18,7 +18,7 @@ const MAX_ITEMS = 5000;
 const MAX_LINES_PER_ITEM = 500;
 
 /** The selection as it is written to disk. */
-export function encode({ items, lines, site = {}, savedAt }) {
+export function encode({ items, lines, style, site = {}, savedAt }) {
   const clean = {};
   for (const [id, ns] of Object.entries(lines ?? {})) {
     const kept = [...new Set(ns)].filter((n) => Number.isInteger(n) && n >= 0).sort((a, b) => a - b);
@@ -33,6 +33,9 @@ export function encode({ items, lines, site = {}, savedAt }) {
     site: { commit: site.commit ?? null, short: site.short ?? null, dirty: !!site.dirty },
     items: [...new Set(items ?? [])].filter((s) => typeof s === 'string'),
     lines: clean,
+    // Which pre-built style to compile in. Absent means the default, which is
+    // also what every selection saved before styles existed means.
+    style: typeof style === 'string' ? style : null,
   };
 }
 
@@ -44,7 +47,7 @@ const fail = (msg) => {
 
 /**
  * Parse a saved selection. Throws `SelectionError` with a readable message.
- * Returns `{ items:Set, lines:Map<string,Set<number>>, site, savedAt }`.
+ * Returns `{ items:Set, lines:Map<string,Set<number>>, style, site, savedAt }`.
  */
 export function decode(text) {
   let raw;
@@ -83,9 +86,14 @@ export function decode(text) {
   }
 
   const site = raw.site && typeof raw.site === 'object' && !Array.isArray(raw.site) ? raw.site : {};
+  // A name, not a promise that this build has it: a file may have been saved by
+  // a build with styles this one does not. The caller decides what to do about
+  // that, which is why an unknown name is returned rather than rejected.
+  const style = typeof raw.style === 'string' && raw.style.length <= 64 ? raw.style : null;
   return {
     items,
     lines,
+    style,
     savedAt: typeof raw.savedAt === 'string' ? raw.savedAt : null,
     site: {
       commit: typeof site.commit === 'string' ? site.commit : null,

--- a/src/pages/cv/builder.astro
+++ b/src/pages/cv/builder.astro
@@ -227,7 +227,8 @@ const site = buildInfo();
 
     const saveSelection = () => {
       const chosen = boxes().filter((b) => b.checked).map((b) => b.value);
-      const doc = encode({ items: chosen, lines: currentLines(), site: SITE });
+      const doc = encode({ items: chosen, lines: currentLines(),
+                          style: $('style').value, site: SITE });
       // Indented: it is small, and a selection you can read and hand-edit in a
       // text editor is worth more than the bytes saved.
       const blob = new Blob([JSON.stringify(doc, null, 2)], { type: 'application/json' });
@@ -253,8 +254,23 @@ const site = buildInfo();
       applyDetail();
       recount();
 
+      // The style travels with the selection. Set directly rather than through
+      // a change event: applyDetail and recount have already retired any
+      // compiled PDF, and firing one here would only overwrite the message
+      // below with a less specific one.
+      const menu = $('style');
+      const wanted = sel.style ?? 'default';
+      const haveStyle = [...menu.options].some((o) => o.value === wanted);
+      if (haveStyle) menu.value = wanted;
+
       const restored = sel.items.size - missing.length;
       const parts = [`Loaded ${plural(restored, 'entry', 'entries')}.`];
+      // A style this build does not have is worth saying out loud — the PDF
+      // would silently come out in a different design otherwise.
+      if (!haveStyle) {
+        parts.push(`Its style "${wanted}" is not one this page offers; using Default.`);
+        menu.value = 'default';
+      }
       // The commit is why the file carries one. If entries have gone missing,
       // the fix is mechanical, so say what it is rather than only that it broke.
       const from = sel.site.commit;

--- a/tests/selection.test.js
+++ b/tests/selection.test.js
@@ -88,4 +88,27 @@ describe('tolerating the merely odd', () => {
   it('ignores fields it does not know', () => {
     expect(read({ somethingNew: { a: 1 } }).items.size).toBe(0);
   });
+
+  it('carries the style through a round trip', () => {
+    const doc = encode({ items: ['a'], lines: {}, style: 'plain' });
+    expect(doc.style).toBe('plain');
+    expect(decode(JSON.stringify(doc)).style).toBe('plain');
+  });
+
+  it('reads no style as null, so a file saved before styles still loads', () => {
+    // The builder turns null into the default; decode does not decide that.
+    expect(encode({ items: [] }).style).toBeNull();
+    expect(read({}).style).toBeNull();
+    expect(read({ style: 42 }).style).toBeNull();
+  });
+
+  it('returns an unknown style rather than rejecting the file', () => {
+    // A file from a build with a style this one lacks is still a good
+    // selection; the caller says so and falls back.
+    expect(read({ style: 'from-the-future' }).style).toBe('from-the-future');
+  });
+
+  it('refuses an absurdly long style name', () => {
+    expect(read({ style: 'x'.repeat(65) }).style).toBeNull();
+  });
 });


### PR DESCRIPTION
A selection already recorded which entries and which detail lines. The style is the third thing that decides what the PDF looks like, and it was the one you had to remember yourself.

Saving writes it; loading through **Load** restores it.

```json
{
  "format": "starkman-cv-selection",
  "version": 1,
  "items": [ ... ],
  "lines": { ... },
  "style": "plain"
}
```

## No version bump, deliberately

The field is optional in both directions:

- a selection saved **before** styles existed still loads — `decode` reports no style as `null`, and the builder reads that as Default;
- a file written **now** stays readable by a build that ignores the field.

Bumping the version would have made old builds *reject* new files for a field they could safely skip.

## An unknown style loads, and says so

`decode` returns a style name it does not recognise rather than rejecting the file — a selection from a build with a style this one lacks is still a perfectly good list of entries. The builder falls back to Default and names what it could not honour:

> Loaded 98 entries. Its style "from-the-future" is not one this page offers; using Default.

Without that line the PDF would quietly come out in a different design from the one saved.

## Verified in the browser, end to end

Saved with the menu on **Default - 🎨**, then loaded the real file back through the file input after putting the page in a different state:

| | before load | after load |
|---|---|---|
| style menu | `default` | **`plain`** |
| the entry I unticked | re-ticked | **unticked again** |

And the two edge cases, driven the same way:

| file | menu after | message |
|---|---|---|
| no `style` field (pre-styles) | `default` | no complaint — nothing was lost |
| `style: "from-the-future"` | `default` | names the style it could not offer |

## One implementation note

The menu is set directly rather than by dispatching a `change` event. `applyDetail()` and `recount()` have already retired any compiled PDF by that point (#57), so a change event would add nothing except replacing the load's own specific message with a vaguer one.

## Tests

Four new cases in `tests/selection.test.js` — round trip, absent style, unknown style, and an absurdly long style name — bringing the suite to **126**. Full `npm test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
