### PR TITLE
Drop the lead card's underline on the home page

### DIFF
--- a/src/components/SoftwareSection.astro
+++ b/src/components/SoftwareSection.astro
@@ -41,7 +41,7 @@ const trail = (s) => {
 const hasPaper = (s) => (softwarePaper(s) ? 'yes' : undefined);
 ---
 {lead && (
-  <div class="lead" data-paper={hasPaper(lead)}>
+  <div class:list={['lead', !tail && 'lead--last']} data-paper={hasPaper(lead)}>
     <div class="name"><a href={href(lead)}>{lead.title}</a></div>
     {lead.role && <div class="role-line">{lead.role}</div>}
     <p>{lead.details ?? lead.summary}</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -186,10 +186,17 @@ h2{
   margin-bottom:2rem; position:relative;
 }
 /* The divider now sits in the gap below the box rather than inside its tint. */
+/* The lead's underline is the first of the tier dividers, not decoration: it
+   marks the boundary between the lead and the tier below it, and matches
+   .tierbreak's 32% width so a page of them reads as one series. On the home
+   page there are no tiers below — the section stops after the headline grid —
+   so the rule was one hairline floating in a gap, separating the last thing
+   from nothing. */
 .lead::after{
   content:""; position:absolute; bottom:-1.05rem; left:50%; transform:translateX(-50%);
   width:32%; height:1px; background:var(--ink-faint); opacity:.24;
 }
+.lead--last::after{content:none}
 .lead .name{font-family:var(--mono); font-size:1.3rem; font-weight:500; letter-spacing:-.01em}
 .lead .role-line{
   font-family:var(--mono); font-size:.68rem; letter-spacing:.09em; text-transform:uppercase;


### PR DESCRIPTION
The small horizontal rule under **Astropy** on the home page, gone.

## What it actually was

Not decoration — `.lead::after` is the **first of the tier dividers**. It marks the boundary between the lead package and the tier below it, and it is drawn at the same 32% width as `.tierbreak` so a run of them reads as one series.

Measured on `/software/`:

| | width |
|---|---|
| `.lead::after` | 203.195px |
| tier divider 1 | 203.195px |
| tier divider 2 | 203.195px |

Three identical hairlines: lead → headline → other → useful.

The home page has **zero** tier dividers. The section stops after the headline grid, so that rule was one hairline floating in a 32px gap, separating the last thing on the page from nothing.

## Scoped by the reason, not by the page

The condition is `tail` — whether the section renders the tiers below — rather than a home-page selector. That is the actual reason the rule does or does not belong, so it stays correct if the home page ever grows a tier or another page drops one.

| page | `tail` | rule |
|---|---|---|
| `/` | false | **gone** |
| `/software/` | true | kept, with its two siblings |

## Unchanged

The 32px gap between the lead and the grid is untouched — only the line went, not the spacing. The lead keeps its tint and its 20px radius.

a11y, 811 links, 126 unit tests.

## If you meant everywhere

`/software/` still shows it, because there it is one of three dividers doing a real job. If you want the lead's rule gone there too — leaving the two dividers between the lower tiers — say so and it is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
