### PR TITLE
Shorten the home page's strap line

### DIFF
--- a/config/person.json
+++ b/config/person.json
@@ -38,7 +38,7 @@
     }
   ],
   "role": "Brinson Prize Fellow",
-  "institution": "MIT Kavli Institute for Astrophysics and Space Research",
+  "titleShort": "Postdoc",
   "github": "nstarman",
   "bio": [
     "I am a computational astrophysicist researching dark matter — what it is, and how it shapes galaxies — mostly by using stellar streams to constrain their gravitational potentials, in the Milky Way and far beyond it with large-scale surveys.",

--- a/config/person.json
+++ b/config/person.json
@@ -39,8 +39,8 @@
   ],
   "role": "Brinson Prize Fellow",
   "titleShort": "Postdoc",
-  "institutionShort": "MIT Kavli",
-  "institutionRest": "Institute for Astrophysics",
+  "institutionShort": "MIT",
+  "institutionRest": "Kavli Institute for Astrophysics",
   "github": "nstarman",
   "bio": [
     "I am a computational astrophysicist researching dark matter — what it is, and how it shapes galaxies — mostly by using stellar streams to constrain their gravitational potentials, in the Milky Way and far beyond it with large-scale surveys.",

--- a/config/person.json
+++ b/config/person.json
@@ -39,6 +39,8 @@
   ],
   "role": "Brinson Prize Fellow",
   "titleShort": "Postdoc",
+  "institutionShort": "MIT Kavli",
+  "institutionRest": "Institute for Astrophysics",
   "github": "nstarman",
   "bio": [
     "I am a computational astrophysicist researching dark matter — what it is, and how it shapes galaxies — mostly by using stellar streams to constrain their gravitational potentials, in the Milky Way and far beyond it with large-scale surveys.",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const background = [...byType('position'), ...byType('education')]
       <div class="ident">
         <h1>{person.name}</h1>
         <p class="role">
-          <em>{person.role}</em> · {person.institution}
+          <em>{person.role}</em> · {person.titleShort} {person.affiliationShort}
         </p>
         <ul class="pills">
           {person.contacts.map((c) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const background = [...byType('position'), ...byType('education')]
       <div class="ident">
         <h1>{person.name}</h1>
         <p class="role">
-          <em>{person.role}</em> · {person.titleShort} {person.affiliationShort}
+          <em>{person.role}</em> · <strong>{person.titleShort} {person.affiliationShort}</strong>
         </p>
         <ul class="pills">
           {person.contacts.map((c) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,7 @@ const background = [...byType('position'), ...byType('education')]
       <div class="ident">
         <h1>{person.name}</h1>
         <p class="role">
-          <em>{person.role}</em> · <strong>{person.titleShort} {person.affiliationShort}</strong>
+          <em>{person.role}</em> · <strong>{person.titleShort}</strong> @ <strong>{person.institutionShort}</strong> {person.institutionRest}
         </p>
         <ul class="pills">
           {person.contacts.map((c) => (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,11 +70,7 @@ h1{
   line-height:1.1; margin:0; letter-spacing:-.015em; text-wrap:balance;
 }
 .role{margin:0; color:var(--ink-mute); font-size:1rem}
-.role em{color:var(--ink-2); font-style:normal; font-weight:500}
-/* The post sits a step above the fellowship it is held under, so it is the
-   heavier of the two — but 600 rather than the browser's 700, which at this
-   size reads as shouting next to the 500 beside it. */
-.role strong{color:var(--ink-2); font-weight:600}
+.role em, .role strong{color:var(--ink-2); font-style:normal; font-weight:500}
 
 .pills{display:flex; flex-wrap:wrap; gap:.45rem; margin-top:.5rem; padding:0; list-style:none}
 .pill{

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,6 +71,10 @@ h1{
 }
 .role{margin:0; color:var(--ink-mute); font-size:1rem}
 .role em{color:var(--ink-2); font-style:normal; font-weight:500}
+/* The post sits a step above the fellowship it is held under, so it is the
+   heavier of the two — but 600 rather than the browser's 700, which at this
+   size reads as shouting next to the 500 beside it. */
+.role strong{color:var(--ink-2); font-weight:600}
 
 .pills{display:flex; flex-wrap:wrap; gap:.45rem; margin-top:.5rem; padding:0; list-style:none}
 .pill{


### PR DESCRIPTION
```
- Brinson Prize Fellow · MIT Kavli Institute for Astrophysics and Space Research
+ Brinson Prize Fellow · Postdoc @ MIT Kavli Institute for Astrophysics
```

## Where the emphasis falls

```html
<em>Brinson Prize Fellow</em> · <strong>Postdoc</strong> @ <strong>MIT</strong> Kavli Institute for Astrophysics
```

Measured in the browser, node by node:

| part | weight |
|---|---|
| Brinson Prize Fellow | 500 |
| ` · ` | 400 |
| **Postdoc** | 500 |
| ` @ ` | 400 |
| **MIT** | 500 |
| ` Kavli Institute for Astrophysics` | 400 |

The emphasised halves share **one rule**, so they cannot drift apart:

```css
.role em, .role strong{color:var(--ink-2); font-style:normal; font-weight:500}
```

Still one line at desktop width.

## The data

Two fields rather than one, split at the point the emphasis splits — the name people recognise, then the rest of the title:

```json
"titleShort": "Postdoc",
"institutionShort": "MIT",
"institutionRest": "Kavli Institute for Astrophysics"
```

`affiliationShort` is untouched. The CV header reads it and wants `"@ MIT Kavli"` as a single string, so the home page composes its own pieces rather than trying to make one field serve both.

The old `person.institution` — the full "…and Space Research" name — is gone. That line was its only reader, confirmed across `src/`, `cv/`, `scripts/` and `tests/` (the `institution` hits in the schema are `item.institution`, a different field on CV entries). This change is what made it dead, so it goes in the same branch rather than waiting for the next audit.

## Unaffected

The CV PDFs read `affiliationShort` directly — `build:pdf` still holds 1page at one page and 2page at two. a11y and 815 links pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

