### PR TITLE
Add months to 24 items, and correct seven years

### DIFF
--- a/data/2020-02-pal5-gaia-dr2.json
+++ b/data/2020-02-pal5-gaia-dr2.json
@@ -7,7 +7,7 @@
     "2page"
   ],
   "date": {
-    "start": "2020"
+    "start": "2020-02"
   },
   "title": "An extended Pal 5 stream in Gaia DR2",
   "status": "published",

--- a/data/2020-09-massey-dialogue-techplomacy-with-consul-general-rana-sarkar.json
+++ b/data/2020-09-massey-dialogue-techplomacy-with-consul-general-rana-sarkar.json
@@ -4,7 +4,7 @@
   "type": "media",
   "cvs": [],
   "date": {
-    "start": "2021"
+    "start": "2020-09"
   },
   "title": "Massey Dialogue: Techplomacy with Consul General Rana Sarkar",
   "details": "Panelist and co-organizer for a salon discussion on the Future of regulating Big Tech",
@@ -12,7 +12,7 @@
   "links": [
     {
       "rel": "homepage",
-      "url": "https://www.youtube.com/watch?v=fUFJn2EZk4Qgle"
+      "url": "https://www.youtube.com/watch?v=fUFJn2EZk4Q"
     }
   ]
 }

--- a/data/2021-05-smithsonian-feature-article.json
+++ b/data/2021-05-smithsonian-feature-article.json
@@ -6,7 +6,7 @@
     "np"
   ],
   "date": {
-    "start": "2021"
+    "start": "2021-05"
   },
   "title": "Smithsonian Feature Article",
   "details": "Interviewed for feature article about my paper",

--- a/data/2022-07-astropy-cycle-iii-funding-grant.json
+++ b/data/2022-07-astropy-cycle-iii-funding-grant.json
@@ -7,7 +7,7 @@
     "2page"
   ],
   "date": {
-    "start": "2022"
+    "start": "2022-07"
   },
   "title": "Astropy Cycle III Funding Grant",
   "tier": "major",

--- a/data/2022-07-astropy-cycle-iii-funding-grants.json
+++ b/data/2022-07-astropy-cycle-iii-funding-grants.json
@@ -7,7 +7,7 @@
     "2page"
   ],
   "date": {
-    "start": "2022"
+    "start": "2022-07"
   },
   "title": "Astropy Cycle III Funding Grants",
   "tier": "major",

--- a/data/2023-01-cosmology-api.json
+++ b/data/2023-01-cosmology-api.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2023"
+    "start": "2023-01"
   },
   "title": "cosmology.api",
   "summary": "A standard interface for cosmology libraries",

--- a/data/2023-02-the-new-scientist.json
+++ b/data/2023-02-the-new-scientist.json
@@ -6,7 +6,7 @@
     "np"
   ],
   "date": {
-    "start": "2023"
+    "start": "2023-02"
   },
   "title": "The New Scientist",
   "details": "Featured in article on various strategies to detect dark matter, including the method from my paper",

--- a/data/2023-05-the-jcr-a-massey-podcast-chatgpt-friend-or-foe.json
+++ b/data/2023-05-the-jcr-a-massey-podcast-chatgpt-friend-or-foe.json
@@ -4,7 +4,7 @@
   "type": "media",
   "cvs": [],
   "date": {
-    "start": "2023"
+    "start": "2023-05"
   },
   "title": "The JCR: A Massey Podcast - ChatGPT: Friend or Foe",
   "details": "Panelist for a public podcast interviewing researchers on how generative AI is used in various scientific fields",

--- a/data/2023-12-quaxed.json
+++ b/data/2023-12-quaxed.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2023-12",
     "present": true
   },
   "title": "quaxed",

--- a/data/2024-02-coordinax.json
+++ b/data/2024-02-coordinax.json
@@ -9,7 +9,7 @@
   ],
   "featured": true,
   "date": {
-    "start": "2024",
+    "start": "2024-02",
     "present": true
   },
   "title": "coordinax",

--- a/data/2024-06-optional-dependencies.json
+++ b/data/2024-06-optional-dependencies.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2024-06",
     "present": true
   },
   "title": "optional_dependencies",

--- a/data/2024-07-dataclassish.json
+++ b/data/2024-07-dataclassish.json
@@ -5,7 +5,7 @@
   "tier": "useful",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2024-07",
     "present": true
   },
   "title": "dataclassish",

--- a/data/2024-07-galactic-dynamics-interoperability.json
+++ b/data/2024-07-galactic-dynamics-interoperability.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2024-07",
     "present": true
   },
   "title": "galactic_dynamics_interoperability",

--- a/data/2024-07-xmmutablemap.json
+++ b/data/2024-07-xmmutablemap.json
@@ -5,7 +5,7 @@
   "tier": "useful",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2024-07",
     "present": true
   },
   "title": "xmmutablemap",

--- a/data/2024-07-zeroth.json
+++ b/data/2024-07-zeroth.json
@@ -5,7 +5,7 @@
   "tier": "useful",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2024-07",
     "present": true
   },
   "title": "zeroth",

--- a/data/2024-08-is-annotated.json
+++ b/data/2024-08-is-annotated.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2024-08",
     "present": true
   },
   "title": "is_annotated",

--- a/data/2024-09-plotting-backends.json
+++ b/data/2024-09-plotting-backends.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2024-09",
     "present": true
   },
   "title": "plotting_backends",

--- a/data/2024-10-mvgkde.json
+++ b/data/2024-10-mvgkde.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2024-10",
     "present": true
   },
   "title": "mvgkde",

--- a/data/2025-02-diffraxtra.json
+++ b/data/2025-02-diffraxtra.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2025-02",
     "present": true
   },
   "title": "diffraxtra",

--- a/data/2025-02-quax-blocks.json
+++ b/data/2025-02-quax-blocks.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2025-02",
     "present": true
   },
   "title": "quax-blocks",

--- a/data/2025-04-streamsculptor.json
+++ b/data/2025-04-streamsculptor.json
@@ -7,7 +7,7 @@
     "2page"
   ],
   "date": {
-    "start": "2025"
+    "start": "2025-04"
   },
   "title": "StreamSculptor: Hamiltonian Perturbation Theory for Stellar Streams in Flexible Potentials with Differentiable Simulations",
   "status": "published",

--- a/data/2025-10-oncequinox.json
+++ b/data/2025-10-oncequinox.json
@@ -5,7 +5,7 @@
   "tier": "useful",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2025-10",
     "present": true
   },
   "title": "oncequinox",

--- a/data/2026-01-phasecurvefit.json
+++ b/data/2026-01-phasecurvefit.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2026-01",
     "present": true
   },
   "title": "phasecurvefit",

--- a/data/2026-02-jaxmore.json
+++ b/data/2026-02-jaxmore.json
@@ -5,7 +5,7 @@
   "tier": "other",
   "cvs": [],
   "date": {
-    "start": "2024",
+    "start": "2026-02",
     "present": true
   },
   "title": "jaxmore",


### PR DESCRIPTION
Closes part of #2. Every month here came from a public record — the source is on each line.

**72 year-only items → 48.** Seven changed year as well, and one dead link is fixed.

## Applied

- [x] `cosmology.api` 2023 → **2023-01** · [repo created 2023-01](https://github.com/cosmology-api/cosmology.api)
- [x] `coordinax` 2024 → **2024-02** · [repo created 2024-02](https://github.com/GalacticDynamics/coordinax)
- [x] `dataclassish` 2024 → **2024-07** · [repo created 2024-07](https://github.com/GalacticDynamics/dataclassish)
- [x] `galactic_dynamics_interoperability` 2024 → **2024-07** · [repo created 2024-07](https://github.com/GalacticDynamics/galactic_dynamics_interoperability)
- [x] `is_annotated` 2024 → **2024-08** · [repo created 2024-08](https://github.com/GalacticDynamics/is_annotated)
- [x] `xmmutablemap` 2024 → **2024-07** · [repo created 2024-07](https://github.com/GalacticDynamics/xmmutablemap)
- [x] `zeroth` 2024 → **2024-07** · [repo created 2024-07](https://github.com/GalacticDynamics/zeroth)
- [x] `mvgkde` 2024 → **2024-10** · [repo created 2024-10](https://github.com/nstarman/mvgkde)
- [x] `plotting_backends` 2024 → **2024-09** · [repo created 2024-09](https://github.com/GalacticDynamics/plotting_backends)
- [x] `optional_dependencies` 2024 → **2024-06** · [repo created 2024-06](https://github.com/GalacticDynamics/optional_dependencies) — first commit is 2024-09; tick the next box instead if you would rather date it from code
- [x] `pal5-gaia-dr2` 2020 → **2020-02** · [10.1093/mnras/staa534](https://doi.org/10.1093/mnras/staa534), online 2020-02-27
- [x] `streamsculptor` 2025 → **2025-04** · [10.3847/1538-4357/adb8e8](https://doi.org/10.3847/1538-4357/adb8e8), online 2025-04-07
- [x] Smithsonian Feature Article 2021 → **2021-05** · [the article](https://www.smithsonianmag.com/science-nature/search-elusive-completely-straight-lightning-bolt-180977665/) is dated May 13, 2021
- [x] The JCR podcast, ChatGPT 2023 → **2023-05** · the [episode URL](https://the-jcr-a.blubrry.net/2023/05/05/chatgpt-friend-or-foe-move-fast-and-break-things/) carries `/2023/05/05/`
- [x] The New Scientist 2023 → **2023-02** · New Scientist's [LinkedIn post](https://ee.linkedin.com/posts/new-scientist_the-hunt-for-dark-matter-the-universes-activity-7031553801664765952-Su4R) of it; the activity id decodes to 2023-02-15
- [x] Astropy Cycle III Funding Grant 2022 → **2022-07** · [Starkman-Cosmology.md](https://github.com/astropy/astropy-project/blob/main/finance/proposal-calls/cycle3/Starkman-Cosmology.md) first committed 2022-07-06
- [x] Astropy Cycle III Funding Grants 2022 → **2022-07** · [Starkman_&_Foreman-Mackey-Units.md](https://github.com/astropy/astropy-project/blob/main/finance/proposal-calls/cycle3/Starkman_%26_Foreman-Mackey-Units.md), same commit
- [x] `quaxed` **2024 → 2023-12** · [repo created 2023-12](https://github.com/GalacticDynamics/quaxed)
- [x] `diffraxtra` **2024 → 2025-02** · [repo created 2025-02](https://github.com/GalacticDynamics/diffraxtra)
- [x] `quax-blocks` **2024 → 2025-02** · [repo created 2025-02](https://github.com/GalacticDynamics/quax-blocks)
- [x] `oncequinox` **2024 → 2025-10** · [repo created 2025-10](https://github.com/GalacticDynamics/oncequinox)
- [x] `phasecurvefit` **2024 → 2026-01** · [repo created 2026-01](https://github.com/GalacticDynamics/phasecurvefit)
- [x] `jaxmore` **2024 → 2026-02** · [repo created 2026-02](https://github.com/GalacticDynamics/jaxmore)
- [x] Massey Dialogue: Techplomacy **2021 → 2020-09** · [the video](https://www.youtube.com/watch?v=fUFJn2EZk4Q) was uploaded 2020-09-23, titled "The Future of Regulating Big Tech", matching the description on the record
- [x] Fix that record's URL — it is stored as `...watch?v=fUFJn2EZk4Qgle`, and the stray `gle` makes it a dead link

## Where the months came from

| kind | source |
|---|---|
| software | the repository's creation date on GitHub |
| publications | Crossref `published-online` — the convention three of your four already-dated papers follow |
| media | each item's own dateline; for New Scientist, whose site blocks fetching, the publisher's LinkedIn post of the article, whose activity id decodes to 2023-02-15 |
| grants | the first commit of the proposal file in `astropy/astropy-project` |

## Seven changed year, not just month

The software dates looked batch-set to 2024 and the repositories disagree — by fifteen months for `jaxmore`. The Massey Dialogue was recorded as 2021 and the video was uploaded in September 2020.

```
quaxed        2024 -> 2023-12      diffraxtra    2024 -> 2025-02
quax-blocks   2024 -> 2025-02      oncequinox    2024 -> 2025-10
phasecurvefit 2024 -> 2026-01      jaxmore       2024 -> 2026-02
Massey Dialogue: Techplomacy  2021 -> 2020-09
```

## The dead link

That Massey record's URL was stored as `...watch?v=fUFJn2EZk4Qgle` — the stray `gle` made it a 404. It returns 200 now.

## Not in this PR

Four items you left unticked, because the evidence and the record mean different things and that is your call: `trackstream` (repo 2020-07 vs recorded 2024), `macro_lightning` (2019-08 vs 2021), `unxt` (2023-12 vs 2024), and `astropy` (first commit 2020-08, but 2021 is when the coordinator role starts). The remaining 44 have no public record at all.

## Checks

`npm test` — 126 unit tests, schema both directions, bibtex, a11y, 815 links, and **180 filenames match `<date.start>-<id>.json`** after 24 renames. `build:pdf` still holds 1page at one page and 2page at two.

Sorting visibly improved: the CV's software section now runs 2026-02, 2026-01, 2025-10, 2025-02… instead of a block of undifferentiated 2024s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
