### PR TITLE
Place 53 talks on the map, and draw it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,37 @@ those four buckets, and `config/presets.json` maps each to a heading.
 Talks", "Selected Presentations" and "Conferences & Workshops" — `kind` carries
 the distinction, including `attended` for a meeting where you presented nothing.
 
+### `location` — a place, never an institution
+
+`location` is what the conference map pins, so it has one format:
+
+```
+City, ST, Country      US and Canada — "Cleveland, OH, USA", "Toronto, ON, Canada"
+City, Country          everywhere else — "Lausanne, Switzerland"
+Online                 a meeting with no venue
+```
+
+Not `MIT, USA` — that is an institution, and a geocoder cannot place it. Not
+`TO, CA` either: `CA` reads as California, which is the failure this format
+exists to prevent, and it puts the pin 3,500 km from Toronto without ever
+looking wrong.
+
+After adding one, resolve its coordinates once and commit them:
+
+```bash
+node scripts/geocode-places.mjs           # fills in only what is missing
+node scripts/geocode-places.mjs --check   # exit 1 if anything is unplaced
+```
+
+Coordinates live in `config/places.json` so the site and CI never call a
+geocoder. The script skips anything not in the format above, and checks the
+`matched` string it wrote — Nominatim answers "Durham, UK" with the county, not
+the city. Correct a wrong pin by hand; the script never overwrites one.
+
+A talk whose location is missing or unsettled is not dropped — it is listed
+under the map as not placed. That is deliberate, so a missing coordinate is
+visible rather than silent.
+
 ### Publications must produce valid BibTeX
 
 The renderer emits a `.bib` file, so publication entries carry everything a

--- a/config/places.json
+++ b/config/places.json
@@ -1,11 +1,21 @@
 {
-  "$comment": "Institution coordinates, resolved once with scripts/geocode-places.mjs and committed so the site and CI never call a geocoder. `matched` is what the geocoder thought it found — check it before trusting a pin. Safe to correct by hand: the script only fills in what is missing.",
+  "$comment": "Coordinates for every place the site pins — collaborator institutions and presentation locations alike — resolved once with scripts/geocode-places.mjs and committed so the site and CI never call a geocoder. `matched` is what the geocoder thought it found — check it before trusting a pin. Safe to correct by hand: the script only fills in what is missing.",
   "source": "https://nominatim.openstreetmap.org (ODbL)",
   "places": {
+    "A Coruña, Spain": {
+      "lat": 43.3466,
+      "lon": -8.4127,
+      "matched": "A Coruña, Galicia, España"
+    },
     "Arcetri Astrophysical Observatory (INAF)": {
       "lat": 43.7502,
       "lon": 11.2542,
       "matched": "Osservatorio astrofisico di Arcetri, Firenze (geocoded)"
+    },
+    "Atlanta, GA, USA": {
+      "lat": 33.7545,
+      "lon": -84.3898,
+      "matched": "Atlanta, Fulton County, Georgia, United States"
     },
     "California Institute of Technology": {
       "lat": 34.137,
@@ -21,6 +31,11 @@
       "lat": 34.2015,
       "lon": -118.173,
       "matched": "Jet Propulsion Laboratory, Pasadena (geocoded)"
+    },
+    "Cambridge, MA, USA": {
+      "lat": 42.3656,
+      "lon": -71.104,
+      "matched": "Cambridge, Middlesex County, Massachusetts, United States"
     },
     "Canadian Institute for Advanced Research": {
       "lat": 43.6596,
@@ -67,10 +82,35 @@
       "lon": -1.0161,
       "matched": "Centro de Estudios de Física del Cosmos de Aragón, VF-TE-02, Arcos de las Salinas, Gúdar-Javalambre, Teruel, Aragón, España"
     },
+    "Cleveland, OH, USA": {
+      "lat": 41.4997,
+      "lon": -81.6937,
+      "matched": "Cleveland, Cuyahoga County, Ohio, United States"
+    },
+    "College Station, TX, USA": {
+      "lat": 30.6184,
+      "lon": -96.3456,
+      "matched": "College Station, Brazos County, Texas, United States"
+    },
     "Columbia University": {
       "lat": 40.8078,
       "lon": -73.9625,
       "matched": "Columbia University, West 109th Street, Manhattan Valley, Manhattan Community Board 7, Manhattan, New York County, New York, 10027, United States"
+    },
+    "Copenhagen, Denmark": {
+      "lat": 55.6867,
+      "lon": 12.5701,
+      "matched": "København, Københavns Kommune, Region Hovedstaden, 1357, Danmark"
+    },
+    "Córdoba, Spain": {
+      "lat": 37.8846,
+      "lon": -4.776,
+      "matched": "Córdoba, Andalucía, España"
+    },
+    "Durham, UK": {
+      "lat": 54.7761,
+      "lon": -1.5733,
+      "matched": "hand-placed: Durham city — the geocoder returned the County Durham centroid, 17 km away"
     },
     "European Southern Observatory": {
       "lat": 48.2596,
@@ -92,6 +132,11 @@
       "lon": 13.4062,
       "matched": "Goethe-Institut Berlin, 20, Neue Schönhauser Straße, Scheunenviertel, Spandauer Vorstadt, Mitte, Berlin, 10178, Deutschland"
     },
+    "Hamilton, ON, Canada": {
+      "lat": 43.2561,
+      "lon": -79.8729,
+      "matched": "Hamilton, Golden Horseshoe, Ontario, Canada"
+    },
     "Harvard University": {
       "lat": 42.3754,
       "lon": -71.1219,
@@ -112,6 +157,16 @@
       "lon": -74.6658,
       "matched": "Institute for Advanced Study, Trolley Track Trail, Battlefield Area, Princeton, Mercer County, New Jersey, 08544, United States"
     },
+    "Ithaca, NY, USA": {
+      "lat": 42.4374,
+      "lon": -76.5484,
+      "matched": "Town of Ithaca, Tompkins County, New York, United States"
+    },
+    "Jesi, Italy": {
+      "lat": 43.5234,
+      "lon": 13.256,
+      "matched": "Jesi, Ancona, Marche, 60035, Italia"
+    },
     "Københavns Universitet": {
       "lat": 55.6802,
       "lon": 12.5723,
@@ -121,6 +176,11 @@
       "lat": 36.0505,
       "lon": 103.8545,
       "matched": "兰州大学, 天水中路, 渭源路街道, 兰州市, 城关区, 兰州市, 甘肃省, 730001, 中国"
+    },
+    "Lausanne, Switzerland": {
+      "lat": 46.5218,
+      "lon": 6.6327,
+      "matched": "Lausanne, District de Lausanne, Vaud, Schweiz/Suisse/Svizzera/Svizra"
     },
     "Leibniz Institute for Astrophysics Potsdam": {
       "lat": 52.4053,
@@ -147,11 +207,6 @@
       "lon": 13.191,
       "matched": "hand-placed: Lund Observatory, Lund University"
     },
-    "MMT Observatory": {
-      "lat": 31.6883,
-      "lon": -110.885,
-      "matched": "hand-placed: MMT, Mount Hopkins, Arizona (published site coordinates)"
-    },
     "Massachusetts Institute of Technology": {
       "lat": 42.3583,
       "lon": -71.0966,
@@ -167,15 +222,20 @@
       "lon": -122.1835,
       "matched": "Mills College at Northeastern University, 5000, MacArthur Boulevard, Seminary Park, Oakland, Alameda County, California, 94613, United States"
     },
-    "NASA": {
-      "lat": 38.8829,
-      "lon": -77.0164,
-      "matched": "Mary W. Jackson NASA Headquarters, 300, E Street Southwest, Southwest Employment Area, Ward 6, Washington, District of Columbia, 20546, United States"
+    "MMT Observatory": {
+      "lat": 31.6883,
+      "lon": -110.885,
+      "matched": "hand-placed: MMT, Mount Hopkins, Arizona (published site coordinates)"
     },
     "Nanjing University": {
       "lat": 32.0566,
       "lon": 118.7741,
       "matched": "南京大学(鼓楼校区), 上海路, 湖南路街道, 鼓楼区, 南京市, 江苏省, 210093, 中国"
+    },
+    "NASA": {
+      "lat": 38.8829,
+      "lon": -77.0164,
+      "matched": "Mary W. Jackson NASA Headquarters, 300, E Street Southwest, Southwest Employment Area, Ward 6, Washington, District of Columbia, 20546, United States"
     },
     "Netherlands Institute for Radio Astronomy": {
       "lat": 52.8134,
@@ -186,6 +246,11 @@
       "lat": 40.7292,
       "lon": -73.995,
       "matched": "New York University, Sullivan Street, University Village, Manhattan, New York County, New York, 10012, United States"
+    },
+    "New York, NY, USA": {
+      "lat": 40.7127,
+      "lon": -74.006,
+      "matched": "New York, United States"
     },
     "Northeastern University": {
       "lat": 42.3351,
@@ -202,15 +267,55 @@
       "lon": -118.1334,
       "matched": "The Carnegie Observatories, Pasadena, CA (geocoded)"
     },
+    "Paris, France": {
+      "lat": 48.8535,
+      "lon": 2.3484,
+      "matched": "Paris, Île-de-France, France métropolitaine, France"
+    },
+    "Pasadena, CA, USA": {
+      "lat": 34.1477,
+      "lon": -118.1442,
+      "matched": "Pasadena, Los Angeles County, California, United States"
+    },
+    "Pittsburgh, PA, USA": {
+      "lat": 40.4407,
+      "lon": -80.0026,
+      "matched": "Pittsburgh, Allegheny County, Pennsylvania, United States"
+    },
+    "Portoferraio, Italy": {
+      "lat": 42.7978,
+      "lon": 10.2993,
+      "matched": "Portoferraio, Livorno, Toscana, 57037, Italia"
+    },
+    "Portsmouth, UK": {
+      "lat": 50.8,
+      "lon": -1.0906,
+      "matched": "Portsmouth, England, United Kingdom"
+    },
+    "Potsdam, Germany": {
+      "lat": 52.4009,
+      "lon": 13.0591,
+      "matched": "Potsdam, Brandenburg, Deutschland"
+    },
     "Princeton University": {
       "lat": 40.3387,
       "lon": -74.6584,
       "matched": "Princeton University, Alexander Street, Princeton, Mercer County, New Jersey, 08540, United States"
     },
+    "Princeton, NJ, USA": {
+      "lat": 40.3497,
+      "lon": -74.6597,
+      "matched": "Princeton, Mercer County, New Jersey, United States"
+    },
     "Rice University": {
       "lat": 29.7168,
       "lon": -95.4048,
       "matched": "Rice University, 6100, Main Street, University Place, Houston, Harris County, Texas, 77005, United States"
+    },
+    "Rochester, NY, USA": {
+      "lat": 43.1573,
+      "lon": -77.6152,
+      "matched": "City of Rochester, Monroe County, New York, United States"
     },
     "Ruprecht-Karls-Universität Heidelberg": {
       "lat": 49.4186,
@@ -227,10 +332,20 @@
       "lon": -74.4645,
       "matched": "Rutgers University, Piscataway, NJ (geocoded)"
     },
+    "Santa Cruz, CA, USA": {
+      "lat": 36.9741,
+      "lon": -122.0308,
+      "matched": "hand-placed: Santa Cruz city — the geocoder returned the Santa Cruz County centroid"
+    },
     "Savitribai Phule Pune University": {
       "lat": 18.5528,
       "lon": 73.8266,
       "matched": "Savitribai Phule Pune University, University Road, Model Colony, Pune, Pune City Subdistrict, Pune, Maharashtra, 411007, India"
+    },
+    "Seattle, WA, USA": {
+      "lat": 47.6038,
+      "lon": -122.3301,
+      "matched": "Seattle, King County, Washington, United States"
     },
     "Simons Foundation": {
       "lat": 40.7392,
@@ -272,6 +387,11 @@
       "lon": -3.189,
       "matched": "Edinburgh University Library, 30, George Square, Pleasance, Southside, City of Edinburgh, Alba / Scotland, EH8 9LJ, United Kingdom"
     },
+    "Toronto, ON, Canada": {
+      "lat": 43.6535,
+      "lon": -79.3839,
+      "matched": "Toronto, Golden Horseshoe, Ontario, Canada"
+    },
     "Univ. of Oregon": {
       "lat": 44.0444,
       "lon": -123.0718,
@@ -286,6 +406,26 @@
       "lat": 41.2214,
       "lon": 1.7301,
       "matched": "Escola Politècnica Superior d''Enginyeria de Vilanova i la Geltrú (EPSEVG), 1, Avinguda de Víctor Balaguer, Barri de Mar, Vilanova i la Geltrú, Garraf, Barcelona, Catalunya, 08800, España"
+    },
+    "Università di Bologna": {
+      "lat": 44.4983,
+      "lon": 11.3545,
+      "matched": "Università di Bologna, Via dei Bibiena, Ghetto ebraico, Irnerio, Santo Stefano, Bologna, Emilia-Romagna, 40126, Italia"
+    },
+    "Universität Bern": {
+      "lat": 46.951,
+      "lon": 7.4387,
+      "matched": "Universität Bern, Falkenplatz, Länggasse, Stadtteil II, Bern, Verwaltungskreis Bern-Mittelland, Verwaltungsregion Bern-Mittelland, Bern/Berne, 3012, Schweiz/Suisse/Svizzera/Svizra"
+    },
+    "Universität Innsbruck": {
+      "lat": 47.2633,
+      "lon": 11.3844,
+      "matched": "Universität Innsbruck - Campus Innrain, Christoph-Probst-Platz, Innenstadt, Innsbruck, Tirol, 6020, Österreich"
+    },
+    "Université Lyon 1": {
+      "lat": 45.7809,
+      "lon": 4.8663,
+      "matched": "Université Lyon 1, Avenue Claude Bernard, Tonkin, Villeurbanne, Lyon, Métropole de Lyon, Rhône, Auvergne-Rhône-Alpes, France métropolitaine, 69100, France"
     },
     "University College London": {
       "lat": 51.5242,
@@ -407,30 +547,15 @@
       "lon": -89.431,
       "matched": "University of Wisconsin-Madison, Speedway Road, Regent, Madison, Dane County, Wisconsin, 53726, United States"
     },
-    "Università di Bologna": {
-      "lat": 44.4983,
-      "lon": 11.3545,
-      "matched": "Università di Bologna, Via dei Bibiena, Ghetto ebraico, Irnerio, Santo Stefano, Bologna, Emilia-Romagna, 40126, Italia"
-    },
-    "Universität Bern": {
-      "lat": 46.951,
-      "lon": 7.4387,
-      "matched": "Universität Bern, Falkenplatz, Länggasse, Stadtteil II, Bern, Verwaltungskreis Bern-Mittelland, Verwaltungsregion Bern-Mittelland, Bern/Berne, 3012, Schweiz/Suisse/Svizzera/Svizra"
-    },
-    "Universität Innsbruck": {
-      "lat": 47.2633,
-      "lon": 11.3844,
-      "matched": "Universität Innsbruck - Campus Innrain, Christoph-Probst-Platz, Innenstadt, Innsbruck, Tirol, 6020, Österreich"
-    },
-    "Université Lyon 1": {
-      "lat": 45.7809,
-      "lon": 4.8663,
-      "matched": "Université Lyon 1, Avenue Claude Bernard, Tonkin, Villeurbanne, Lyon, Métropole de Lyon, Rhône, Auvergne-Rhône-Alpes, France métropolitaine, 69100, France"
-    },
     "Universtity of Wisconsin": {
       "lat": 43.0766,
       "lon": -89.4125,
       "matched": "hand-placed: University of Wisconsin-Madison. The name is misspelt on the ORCID record it came from, and is kept as written so the collector still matches it."
+    },
+    "Valencia, Spain": {
+      "lat": 39.4697,
+      "lon": -0.3763,
+      "matched": "València, Comarca de València, València / Valencia, Comunitat Valenciana, España"
     },
     "Valencian International University": {
       "lat": 39.4715,

--- a/data/2016-08-cornell-classe-summer-seminar-talk.json
+++ b/data/2016-08-cornell-classe-summer-seminar-talk.json
@@ -8,5 +8,6 @@
   },
   "title": "Cornell CLASSE Summer Seminar (Talk)",
   "kind": "contributed",
+  "location": "Ithaca, NY, USA",
   "details": "Coherent curvature radiation in a neutron star’s monopolar magnetic field"
 }

--- a/data/2017-06-dwarf-galaxies-on-the-shoulders-of-giants.json
+++ b/data/2017-06-dwarf-galaxies-on-the-shoulders-of-giants.json
@@ -8,5 +8,6 @@
   },
   "title": "Dwarf Galaxies on the Shoulders of Giants",
   "kind": "contributed",
+  "location": "Cleveland, OH, USA",
   "details": "Workshop on topics related to dwarf galaxies and the dark matter problem Conference Volunteer"
 }

--- a/data/2017-08-cwru-astronomy-summer-seminar-talk.json
+++ b/data/2017-08-cwru-astronomy-summer-seminar-talk.json
@@ -8,5 +8,6 @@
   },
   "title": "CWRU Astronomy Summer Seminar (Talk)",
   "kind": "contributed",
+  "location": "Cleveland, OH, USA",
   "details": "Understanding the Dark Matter distribution in galaxies using maximal disks"
 }

--- a/data/2017-10-cwru-physics-seminar-talk.json
+++ b/data/2017-10-cwru-physics-seminar-talk.json
@@ -8,5 +8,6 @@
   },
   "title": "CWRU Physics Seminar (Talk)",
   "kind": "contributed",
+  "location": "Cleveland, OH, USA",
   "details": "Understanding the Dark Matter distribution in galaxies using maximal disks"
 }

--- a/data/2017-cosmology-overview-at-cwru-origins-talk.json
+++ b/data/2017-cosmology-overview-at-cwru-origins-talk.json
@@ -8,5 +8,6 @@
   },
   "title": "Cosmology Overview at CWRU Origins (Talk)",
   "kind": "invited",
+  "location": "Cleveland, OH, USA",
   "details": "The Universe: A Brief History"
 }

--- a/data/2018-05-cwru-source-intersections-poster.json
+++ b/data/2018-05-cwru-source-intersections-poster.json
@@ -8,5 +8,6 @@
   },
   "title": "CWRU SOURCE Intersections (Poster)",
   "kind": "contributed",
+  "location": "Cleveland, OH, USA",
   "details": "A new algorithm to quantify maximal disks"
 }

--- a/data/2018-06-the-standard-model-at-50-years.json
+++ b/data/2018-06-the-standard-model-at-50-years.json
@@ -8,6 +8,7 @@
   },
   "title": "The Standard Model at 50 Years",
   "kind": "contributed",
+  "location": "Cleveland, OH, USA",
   "details": "A Celebratory Symposium for the Standard Model Conference Volunteer",
   "links": [
     {

--- a/data/2019-07-comscicon-canada-2019.json
+++ b/data/2019-07-comscicon-canada-2019.json
@@ -8,7 +8,7 @@
   },
   "title": "ComSciCon Canada 2019",
   "kind": "attended",
-  "location": "Hamilton, CA",
+  "location": "Hamilton, ON, Canada",
   "details": "Selected participant at Canada’s first national science communication workshop for graduate students",
   "links": [
     {

--- a/data/2019-08-great-lakes-cosmology-workshop-talk.json
+++ b/data/2019-08-great-lakes-cosmology-workshop-talk.json
@@ -8,5 +8,6 @@
   },
   "title": "Great Lakes Cosmology Workshop (Talk)",
   "kind": "contributed",
+  "location": "Rochester, NY, USA",
   "details": "Parameterizing the recombination visibility function"
 }

--- a/data/2019-09-5th-gaia-challenge-conference-talk-2.json
+++ b/data/2019-09-5th-gaia-challenge-conference-talk-2.json
@@ -8,5 +8,6 @@
   },
   "title": "5th Gaia Challenge Conference (Talk)",
   "kind": "contributed",
+  "location": "Paris, France",
   "details": "Using Manifold Learning Techniques to Identify Stream Progenitors"
 }

--- a/data/2019-09-5th-gaia-challenge-conference-talk.json
+++ b/data/2019-09-5th-gaia-challenge-conference-talk.json
@@ -8,5 +8,6 @@
   },
   "title": "5th Gaia Challenge Conference (Talk)",
   "kind": "contributed",
+  "location": "Paris, France",
   "details": "Extending the Pal5 Stream Detection Limits"
 }

--- a/data/2019-10-astronomy-11.json
+++ b/data/2019-10-astronomy-11.json
@@ -8,7 +8,7 @@
   },
   "title": "Astronomy 11",
   "kind": "organizer",
-  "location": "TO, CA",
+  "location": "Toronto, ON, Canada",
   "details": "Role: Local Organizing Committee member and lead workshop on scientific plotting",
   "links": [
     {

--- a/data/2019-12-30th-texas-symposium-on-relativistic-astrophysics-talk.json
+++ b/data/2019-12-30th-texas-symposium-on-relativistic-astrophysics-talk.json
@@ -8,5 +8,6 @@
   },
   "title": "30th Texas Symposium On Relativistic Astrophysics (Talk)",
   "kind": "contributed",
+  "location": "Portsmouth, UK",
   "details": "Resolving the Recombination Visibility Function Width Tension Awarded best graduate student presentation"
 }

--- a/data/2020-08-stsci-2020-the-local-group-assembly-and-evolution-symposium.json
+++ b/data/2020-08-stsci-2020-the-local-group-assembly-and-evolution-symposium.json
@@ -8,5 +8,6 @@
   },
   "title": "STScI 2020 The Local Group: Assembly and Evolution Symposium (Poster)",
   "kind": "contributed",
+  "location": "Online",
   "details": "Constraints on Milky Way Halo Triaxiality from Palomar 5"
 }

--- a/data/2021-05-casca-agm-poster-2.json
+++ b/data/2021-05-casca-agm-poster-2.json
@@ -8,5 +8,6 @@
   },
   "title": "CASCA AGM (Poster)",
   "kind": "contributed",
+  "location": "Online",
   "details": "Straight Lightning as a Signature of Macroscopic Dark Matter"
 }

--- a/data/2021-05-casca-agm-poster.json
+++ b/data/2021-05-casca-agm-poster.json
@@ -8,5 +8,6 @@
   },
   "title": "CASCA AGM (Poster)",
   "kind": "contributed",
+  "location": "Online",
   "details": "Stellar Stream Track Reconstruction, with Errors"
 }

--- a/data/2021-06-aas-2021-talk.json
+++ b/data/2021-06-aas-2021-talk.json
@@ -8,5 +8,6 @@
   },
   "title": "AAS 2021 (Talk)",
   "kind": "contributed",
+  "location": "Online",
   "details": "Astropy Tutorials on Units & Constants, Coordinates, and Cosmology"
 }

--- a/data/2022-10-cats-2022.json
+++ b/data/2022-10-cats-2022.json
@@ -10,6 +10,7 @@
   },
   "title": "CATS-2022",
   "kind": "contributed",
+  "location": "Pasadena, CA, USA",
   "details": "Streams22: A workshop for assembling a Community Atlas of Tidal Streams",
   "links": [
     {

--- a/data/2023-01-aas-2023-talk.json
+++ b/data/2023-01-aas-2023-talk.json
@@ -10,5 +10,6 @@
   },
   "title": "AAS 2023 (Talk)",
   "kind": "contributed",
+  "location": "Seattle, WA, USA",
   "details": "Astropy Tutorials on Units & Constants"
 }

--- a/data/2023-01-cita-seminar.json
+++ b/data/2023-01-cita-seminar.json
@@ -11,5 +11,6 @@
   },
   "title": "CITA Seminar",
   "kind": "invited",
+  "location": "Toronto, ON, Canada",
   "details": "Astropy Cosmology: the Present and the Expanding Future"
 }

--- a/data/2023-02-the-future-of-astrophysical-data.json
+++ b/data/2023-02-the-future-of-astrophysical-data.json
@@ -10,6 +10,7 @@
   },
   "title": "The Future of Astrophysical Data",
   "kind": "attended",
+  "location": "New York, NY, USA",
   "details": "Infrastructure & NYC, USA",
   "links": [
     {

--- a/data/2023-03-iaus379-dynamical-masses-of-local-group-galaxies-poster.json
+++ b/data/2023-03-iaus379-dynamical-masses-of-local-group-galaxies-poster.json
@@ -10,6 +10,7 @@
   },
   "title": "IAUS379: Dynamical Masses of Local Group Galaxies (Poster)",
   "kind": "contributed",
+  "location": "Potsdam, Germany",
   "details": "Stellar Stream Track Reconstruction, with Errors",
   "links": [
     {

--- a/data/2023-05-astropy-conference-talk.json
+++ b/data/2023-05-astropy-conference-talk.json
@@ -10,5 +10,6 @@
   },
   "title": "Astropy Conference (Talk)",
   "kind": "contributed",
+  "location": "Cambridge, MA, USA",
   "details": "An Interoperable Future with Astropy"
 }

--- a/data/2023-10-desc-sprint-week.json
+++ b/data/2023-10-desc-sprint-week.json
@@ -9,5 +9,6 @@
     "start": "2023-10"
   },
   "title": "DESC sprint week",
-  "kind": "contributed"
+  "kind": "contributed",
+  "location": "Pittsburgh, PA, USA"
 }

--- a/data/2024-05-division-on-dynamical-astronomy-55-talk.json
+++ b/data/2024-05-division-on-dynamical-astronomy-55-talk.json
@@ -10,6 +10,7 @@
   },
   "title": "Division on Dynamical Astronomy #55 (Talk)",
   "kind": "contributed",
+  "location": "Toronto, ON, Canada",
   "details": "Stream Members Only: Data-Driven Characterization of Stellar Streams",
   "links": [
     {

--- a/data/2024-05-from-jax-to-galax.json
+++ b/data/2024-05-from-jax-to-galax.json
@@ -10,7 +10,7 @@
   },
   "title": "From JAX to Galax",
   "kind": "attended",
-  "location": "TO, CA",
+  "location": "Toronto, ON, Canada",
   "details": "Workshop at Globular Clusters and Their Tidal Tails",
   "links": [
     {

--- a/data/2024-05-globular-clusters-and-their-tidal-tails-talk.json
+++ b/data/2024-05-globular-clusters-and-their-tidal-tails-talk.json
@@ -10,6 +10,7 @@
   },
   "title": "Globular Clusters and Their Tidal Tails (Talk)",
   "kind": "contributed",
+  "location": "Toronto, ON, Canada",
   "details": "Stream Members Only: Data-Driven Characterization of Stellar Streams",
   "links": [
     {

--- a/data/2024-08-streams-24-the-theory-edition-talk.json
+++ b/data/2024-08-streams-24-the-theory-edition-talk.json
@@ -10,6 +10,7 @@
   },
   "title": "Streams 24: The theory edition (Talk)",
   "kind": "contributed",
+  "location": "Durham, UK",
   "details": "From JAX to Galax, a new generation of stellar stream tools Using ML to select stellar stream members",
   "links": [
     {

--- a/data/2024-10-cwru-seminar.json
+++ b/data/2024-10-cwru-seminar.json
@@ -11,6 +11,7 @@
   },
   "title": "CWRU Seminar",
   "kind": "invited",
+  "location": "Cleveland, OH, USA",
   "details": "Stream Members Only: Data-Driven Characterization of Stellar Streams for Inference on the Galactic Potential",
   "links": [
     {

--- a/data/2024-10-jaxtronomy-workshop.json
+++ b/data/2024-10-jaxtronomy-workshop.json
@@ -10,7 +10,7 @@
   },
   "title": "JAXtronomy Workshop",
   "kind": "organizer",
-  "location": "NYC, USA",
+  "location": "New York, NY, USA",
   "details": "Role: SOC",
   "links": [
     {

--- a/data/2025-01-gaia-hackathon-2.json
+++ b/data/2025-01-gaia-hackathon-2.json
@@ -10,7 +10,7 @@
   },
   "title": "Gaia Hackathon",
   "kind": "organizer",
-  "location": "MIT, USA",
+  "location": "Cambridge, MA, USA",
   "details": "Role: LOC",
   "links": [
     {

--- a/data/2025-03-dark-seminar-copenhagen-2.json
+++ b/data/2025-03-dark-seminar-copenhagen-2.json
@@ -11,5 +11,6 @@
   },
   "title": "DARK seminar (Copenhagen)",
   "kind": "invited",
+  "location": "Copenhagen, Denmark",
   "details": "Bayesian models for detecting streams in LSST data"
 }

--- a/data/2025-05-dda-56.json
+++ b/data/2025-05-dda-56.json
@@ -10,6 +10,7 @@
   },
   "title": "DDA #56",
   "kind": "contributed",
+  "location": "Atlanta, GA, USA",
   "details": "Extra-Galactic Gravity using Streams (EGGS) from Euclid's Zoo(niverse)",
   "links": [
     {

--- a/data/2025-05-division-of-dynamical-astronomy-56.json
+++ b/data/2025-05-division-of-dynamical-astronomy-56.json
@@ -10,7 +10,7 @@
   },
   "title": "Division of Dynamical Astronomy #56",
   "kind": "organizer",
-  "location": "GIT, USA",
+  "location": "Atlanta, GA, USA",
   "details": "Role: SOC",
   "links": [
     {

--- a/data/2025-06-astropy-coordination-meeting.json
+++ b/data/2025-06-astropy-coordination-meeting.json
@@ -10,7 +10,7 @@
   },
   "title": "Astropy Coordination Meeting",
   "kind": "organizer",
-  "location": "Santa Cruz, USA",
+  "location": "Santa Cruz, CA, USA",
   "details": "Role: SOC",
   "links": [
     {

--- a/data/2025-09-cca-software-seminar-nyc.json
+++ b/data/2025-09-cca-software-seminar-nyc.json
@@ -11,5 +11,6 @@
   },
   "title": "CCA Software seminar (NYC)",
   "kind": "invited",
+  "location": "New York, NY, USA",
   "details": "unxt, coordinax, and software development in JAX"
 }

--- a/data/2025-09-cosmology-2025-talk.json
+++ b/data/2025-09-cosmology-2025-talk.json
@@ -10,6 +10,7 @@
   },
   "title": "Cosmology 2025 (Talk)",
   "kind": "contributed",
+  "location": "Portoferraio, Italy",
   "details": "Euclid: The Geometry of Dark Matter Halos from Extragalactic Streams",
   "links": [
     {

--- a/data/2025-09-mki-journal-club-talk.json
+++ b/data/2025-09-mki-journal-club-talk.json
@@ -10,5 +10,6 @@
   },
   "title": "MKI Journal Club (Talk)",
   "kind": "contributed",
+  "location": "Cambridge, MA, USA",
   "details": "Euclid: The Geometry of Dark Matter Halos from Extragalactic Streams"
 }

--- a/data/2025-09-princeton-thunch-seminar-princeton.json
+++ b/data/2025-09-princeton-thunch-seminar-princeton.json
@@ -11,6 +11,7 @@
   },
   "title": "Princeton Thunch Seminar (Princeton)",
   "kind": "invited",
+  "location": "Princeton, NJ, USA",
   "details": "Euclid: The Geometry of Dark Matter Halos from Extragalactic Streams",
   "links": [
     {

--- a/data/2025-10-dark-seminar-copenhagen.json
+++ b/data/2025-10-dark-seminar-copenhagen.json
@@ -11,5 +11,6 @@
   },
   "title": "DARK seminar (Copenhagen)",
   "kind": "invited",
+  "location": "Copenhagen, Denmark",
   "details": "The Geometry of Dark Matter Halos from Extragalactic Streams"
 }

--- a/data/2025-10-iaus-43-talk.json
+++ b/data/2025-10-iaus-43-talk.json
@@ -10,6 +10,7 @@
   },
   "title": "IAUS 43 (Talk)",
   "kind": "contributed",
+  "location": "Córdoba, Spain",
   "details": "Euclid: The Geometry of Dark Matter Halos from Extragalactic Streams",
   "links": [
     {

--- a/data/2025-10-texas-a-m-seminar-texas.json
+++ b/data/2025-10-texas-a-m-seminar-texas.json
@@ -11,5 +11,6 @@
   },
   "title": "Texas A&M Seminar (Texas)",
   "kind": "invited",
+  "location": "College Station, TX, USA",
   "details": "The Geometry of Dark Matter Halos from Extragalactic Streams"
 }

--- a/data/2025-11-tevpa-talk.json
+++ b/data/2025-11-tevpa-talk.json
@@ -10,6 +10,7 @@
   },
   "title": "TeVPA (Talk)",
   "kind": "contributed",
+  "location": "Valencia, Spain",
   "details": "Euclid: The Geometry of Dark Matter Halos from Extragalactic Streams",
   "links": [
     {

--- a/data/2025-11-tevpa-valencia.json
+++ b/data/2025-11-tevpa-valencia.json
@@ -11,5 +11,6 @@
   },
   "title": "TevPA (Valencia)",
   "kind": "invited",
+  "location": "Valencia, Spain",
   "details": "The Geometry of Dark Matter Halos from Extragalactic Streams"
 }

--- a/data/2026-01-gaia-hackathon.json
+++ b/data/2026-01-gaia-hackathon.json
@@ -10,7 +10,7 @@
   },
   "title": "Gaia Hackathon",
   "kind": "organizer",
-  "location": "MIT, USA",
+  "location": "Cambridge, MA, USA",
   "details": "Role: LOC",
   "links": [
     {

--- a/data/2026-02-cwru-seminar-cleveland.json
+++ b/data/2026-02-cwru-seminar-cleveland.json
@@ -11,5 +11,6 @@
   },
   "title": "CWRU Seminar (Cleveland)",
   "kind": "invited",
+  "location": "Cleveland, OH, USA",
   "details": "Computationally Unscrambling EGGS (Extra-Galactic Gravity from Streams)"
 }

--- a/data/2026-06-dark-seminar-talk.json
+++ b/data/2026-06-dark-seminar-talk.json
@@ -10,5 +10,6 @@
   },
   "title": "DARK Seminar (Talk)",
   "kind": "contributed",
+  "location": "Copenhagen, Denmark",
   "details": "Energy Structures of Extragalactic Stellar Streams Reveal Dark Matter Halos"
 }

--- a/data/2026-06-eas-26-s10-lausanne.json
+++ b/data/2026-06-eas-26-s10-lausanne.json
@@ -11,6 +11,7 @@
   },
   "title": "EAS 26-S10 (Lausanne)",
   "kind": "invited",
+  "location": "Lausanne, Switzerland",
   "details": "The Geometry of Dark Matter Halos from Extragalactic Streams",
   "links": [
     {

--- a/data/2026-07-near-field-cosmology-in-the-era-of-big-data-talk.json
+++ b/data/2026-07-near-field-cosmology-in-the-era-of-big-data-talk.json
@@ -10,6 +10,7 @@
   },
   "title": "Near Field Cosmology in the Era of Big Data (Talk)",
   "kind": "contributed",
+  "location": "Toronto, ON, Canada",
   "details": "Energy Structures of Extragalactic Stellar Streams Reveal Dark Matter Halos",
   "links": [
     {

--- a/data/2026-08-marche-iii-big-bang-big-stars-big-computers-jesi.json
+++ b/data/2026-08-marche-iii-big-bang-big-stars-big-computers-jesi.json
@@ -11,5 +11,6 @@
   },
   "title": "Marche III: Big Bang, Big Stars, Big Computers (Jesi)",
   "kind": "invited",
+  "location": "Jesi, Italy",
   "details": "Energy Structures of Extragalactic Stellar Streams Reveal Dark Matter Halos"
 }

--- a/data/2026-08-new-frontiers-in-cosmology-talk.json
+++ b/data/2026-08-new-frontiers-in-cosmology-talk.json
@@ -10,5 +10,6 @@
   },
   "title": "New Frontiers in Cosmology (Talk)",
   "kind": "contributed",
+  "location": "A Coruña, Spain",
   "details": "Energy Structures of Extragalactic Stellar Streams Reveal Dark Matter Halos"
 }

--- a/scripts/geocode-places.mjs
+++ b/scripts/geocode-places.mjs
@@ -1,4 +1,9 @@
-// Resolves each institution in config/collaborators.json to a lat/lon, once.
+// Resolves every place the site pins to a lat/lon, once: each institution in
+// config/collaborators.json, and each `location` on a presentation in data/.
+//
+// Both live in one file because they are the same kind of fact — somewhere on
+// Earth the site draws a dot for — and one committed answer per place means the
+// two maps cannot disagree about where Cambridge is.
 //
 // Issue #22: geocoding at build time would make CI depend on a third-party
 // API, which this repo avoids everywhere else. So this is run by hand and the
@@ -12,9 +17,20 @@
 // honoured below.
 
 import fs from 'node:fs';
+import path from 'node:path';
 
 const OUT = 'config/places.json';
 const collaborators = JSON.parse(fs.readFileSync('config/collaborators.json', 'utf8'));
+
+// A talk with no venue is not a place, and must never become a pin — see #22.
+const ONLINE = 'Online';
+
+// `City, ST, Country` for the US and Canada, `City, Country` elsewhere: the
+// format settled in #67. Anything else is a leftover — `TO, CA` reads as
+// California to a geocoder, and `MIT, USA` is an institution, not a place — so
+// it is skipped rather than resolved into a confident wrong pin.
+const SETTLED = /^[^,]+, (?:[A-Z]{2}, (?:USA|Canada)|[^,]+)$/;
+const isPlaceable = (s) => s !== ONLINE && SETTLED.test(s) && !/^[^,]+, (?:USA|CA)$/.test(s);
 
 const existing = fs.existsSync(OUT) ? JSON.parse(fs.readFileSync(OUT, 'utf8')) : { $comment: '', places: {} };
 const places = existing.places ?? {};
@@ -27,14 +43,27 @@ for (const p of collaborators.people) {
   }
 }
 
+// Presentation locations are already written as a place, so each one is its own
+// query as well as its own key.
+const skipped = new Set();
+for (const f of fs.readdirSync('data').filter((n) => n.endsWith('.json'))) {
+  const item = JSON.parse(fs.readFileSync(path.join('data', f), 'utf8'));
+  if (item.type !== 'presentation' || !item.location) continue;
+  if (isPlaceable(item.location)) wanted.set(item.location, item.location);
+  else if (item.location !== ONLINE) skipped.add(item.location);
+}
+for (const s of [...skipped].sort()) {
+  console.log(`  not a settled place, left unplaced: ${JSON.stringify(s)}`);
+}
+
 const missing = [...wanted.keys()].filter((k) => !places[k]);
 
 if (process.argv.includes('--check')) {
   if (missing.length === 0) {
-    console.log(`  ok       all ${wanted.size} institution(s) placed`);
+    console.log(`  ok       all ${wanted.size} place(s) placed`);
     process.exit(0);
   }
-  console.log(`  ${missing.length} institution(s) have no coordinates:`);
+  console.log(`  ${missing.length} place(s) have no coordinates:`);
   for (const m of missing) console.log(`    ${m}`);
   console.log('  run: node scripts/geocode-places.mjs');
   process.exit(1);
@@ -61,11 +90,12 @@ for (const org of missing) {
 }
 
 fs.writeFileSync(OUT, `${JSON.stringify({
-  $comment: 'Institution coordinates, resolved once with scripts/geocode-places.mjs and '
+  $comment: 'Coordinates for every place the site pins — collaborator institutions and '
+    + 'presentation locations alike — resolved once with scripts/geocode-places.mjs and '
     + 'committed so the site and CI never call a geocoder. `matched` is what the geocoder '
     + 'thought it found — check it before trusting a pin. Safe to correct by hand: the '
     + 'script only fills in what is missing.',
   source: 'https://nominatim.openstreetmap.org (ODbL)',
   places: Object.fromEntries(Object.entries(places).sort(([a], [b]) => a.localeCompare(b))),
 }, null, 2)}\n`);
-console.log(`  ${Object.keys(places).length} institution(s) placed`);
+console.log(`  ${Object.keys(places).length} place(s) placed`);

--- a/src/components/CollabMap.astro
+++ b/src/components/CollabMap.astro
@@ -62,7 +62,7 @@ const label = (pin) =>
 
   <div class="cmap-pick">
     <label for="cmap-who">Show</label>
-    <select id="cmap-who" class="btn btn--sel">
+    <select id="cmap-who" class="cmap-who btn btn--sel">
       <option value="">Everyone</option>
       {people.map((p, i) => <option value={String(i)}>{p.name}</option>)}
     </select>
@@ -111,84 +111,6 @@ const label = (pin) =>
 </figure>
 
 <script>
-  // Progressive enhancement, and only that: with no JavaScript every pin, every
-  // trajectory and every name is already on the page, which is the honest
-  // default anyway. What this adds is the ability to pull one person out of
-  // thirty-four.
-  //
-  // It toggles `hidden` rather than a class so the effect is in the DOM rather
-  // than only in the paint — a screen reader is told the same thing the eye is.
-  const fig = document.querySelector('.cmap');
-  const pick = document.getElementById('cmap-who');
-  if (fig && pick) {
-    const all = (sel) => [...fig.querySelectorAll(sel)];
-    const list = fig.querySelector('.cmap-list');
-
-    const show = (only) => {
-      const mine = (el) => only === '' || el.dataset.c === only;
-      for (const el of all('.cmap-pin, .cmap-trail')) el.style.display = mine(el) ? '' : 'none';
-      // Everyone means the map, and only the map: a roster of thirty-four names
-      // under it is the wall of text the picker exists to avoid.
-      list.hidden = only === '';
-      for (const li of all('.cmap-list > li')) {
-        li.hidden = !mine(li);
-        // The posts are the detail; they belong to whoever was asked for.
-        const posts = li.querySelector('ol');
-        const note = li.querySelector('.cmap-note');
-        // Only the person asked for; the others are hidden anyway, and content
-        // inside a hidden element should not be pretending to be visible.
-        const open = only !== '' && mine(li);
-        if (posts) posts.hidden = !open;
-        if (note) note.hidden = !open;
-      }
-      fig.dataset.only = only;
-    };
-
-    pick.addEventListener('change', () => show(pick.value));
-    show('');
-
-    fig.addEventListener('pointerover', (e) => mark(e.target));
-    fig.addEventListener('pointerleave', () => mark(null));
-    fig.addEventListener('focusin', (e) => mark(e.target));
-    fig.addEventListener('focusout', () => mark(null));
-
-    // Clicking a pin or a trail picks that person, which is what pointing at
-    // something on a map and pressing it ought to do. Hover deliberately does
-    // not: sweeping the cursor across eighty-five pins would rebuild the list
-    // under the reader several times a second. Hover previews by dimming the
-    // others; the click commits.
-    fig.addEventListener('click', (e) => {
-      const owner = e.target.closest?.('.cmap-pin, .cmap-trail');
-      if (!owner) return;
-      pick.value = owner.dataset.c;
-      show(pick.value);
-      // Selecting hides everyone else, so the thing being pointed at is no
-      // longer under the cursor and the dimming has nothing left to say.
-      mark(null);
-    });
-
-    // Hover and keyboard linking between the two halves. The state goes on the
-    // figure rather than being expressed with :has(), because one attribute on
-    // an ancestor is two CSS rules instead of one per person — and because a
-    // pin and its name in the list are in different subtrees, which is exactly
-    // the case :has() is worst at.
-    // Set on the elements rather than expressed as a rule keyed off the figure.
-    // CSS cannot say "this element's data-c matches its ancestor's data-hover"
-    // without one rule per person, and the version that dimmed everything and
-    // lit the match back up did not survive contact with a real browser. This
-    // does one thing and can be checked by reading it back.
-    const dimmable = () => all('.cmap-pin, .cmap-trail, .cmap-list > li');
-    const mark = (el) => {
-      const owner = el?.closest?.('[data-c]');
-      const only = owner?.dataset.c;
-      for (const e of dimmable()) {
-        // Trails carry their own resting opacity, so restoring means clearing
-        // the override rather than writing 1 over the top of it.
-        e.style.opacity = only === undefined || e.dataset.c === only ? '' : '.12';
-      }
-      if (only === undefined) delete fig.dataset.hover;
-      else fig.dataset.hover = only;
-    };
-
-  }
+  import { wireAll } from '../lib/mappick.js';
+  wireAll();
 </script>

--- a/src/components/ConfMap.astro
+++ b/src/components/ConfMap.astro
@@ -1,0 +1,149 @@
+---
+// Where I have given a talk, run a workshop, or shown a poster.
+//
+// Same machinery as the collaborator map — a committed Equal Earth outline, no
+// tiles, so no third party sees a visitor's viewport and the whole thing works
+// offline. See issue #22.
+//
+// The unit is the place, not the talk: a pin's size is how many times I have
+// spoken there. The list underneath is not a fallback but the same data in the
+// form a screen reader, a keyboard, or a small phone can actually use, and it
+// is where the talk titles live in full.
+import { conferenceMap, map } from '../lib/confmap.js';
+
+const conf = conferenceMap();
+const { pins, online, unsettled, unplaced } = conf;
+const plural = (n, one, many = `${one}s`) => `${n} ${n === 1 ? one : many}`;
+
+// Everything that is deliberately not a pin, in one place so the page can own
+// up to it in one sentence rather than three.
+const offMap = online.length + unsettled.length + unplaced.length;
+---
+
+<figure class="cmap cmap--conf">
+  <figcaption>
+    {/* Both keys share a viewBox so the ratio between them is the real one:
+        four times the area, twice the radius. A wider box on the second was
+        squashed back to the same 11px and the two read as one size. */}
+    <span class="cmap-key cmap-key--conf">
+      <svg viewBox="0 0 12 12" aria-hidden="true"><circle cx="6" cy="6" r="2.8" /></svg>
+      one talk
+    </span>
+    <span class="cmap-key cmap-key--conf">
+      <svg viewBox="0 0 12 12" aria-hidden="true"><circle cx="6" cy="6" r="5.6" /></svg>
+      four — a pin's area is its count
+    </span>
+    <a class="cmap-proj" href="https://en.wikipedia.org/wiki/Equal_Earth_projection">Equal Earth projection</a>
+  </figcaption>
+
+  <svg viewBox={`0 0 ${map.width} ${map.height}`} role="img"
+       aria-label={`World map: ${plural(conf.talks, 'talk')} given in `
+                 + `${plural(pins.length, 'place')}, on an Equal Earth projection. `
+                 + `The same information is listed below.`}>
+    <path class="cmap-land" d={map.land} />
+    {/* Drawn over the land in the ocean's colour rather than cut out of it:
+        two paths and no fill-rule to get wrong. */}
+    <path class="cmap-lakes" d={map.lakes} />
+
+    {/* Biggest first, so a place with one talk is never hidden under a place
+        with eight — the pins are filled, and painting order is the only depth
+        an SVG has. */}
+    {[...pins].sort((a, b) => b.r - a.r).map((pin) => (
+      <g class="cmap-pin" data-c={pins.indexOf(pin)} style={`--h:${pin.hue}; --r:${pin.r}`}>
+        {/* <title> is the native tooltip and the accessible name at once. */}
+        <title>{pin.place} — {plural(pin.talks.length, 'talk')}</title>
+        {/* `r` twice on purpose: the attribute is what a stylesheet-less render
+            draws, --r is what the stylesheet scales for hover and small screens. */}
+        <circle cx={pin.x.toFixed(2)} cy={pin.y.toFixed(2)} r={pin.r} />
+      </g>
+    ))}
+  </svg>
+
+  <div class="cmap-pick">
+    <label for="conf-who">Show</label>
+    <select id="conf-who" class="cmap-who btn btn--sel">
+      <option value="">Everywhere</option>
+      {pins.map((p, i) => (
+        <option value={String(i)}>{p.place} ({p.talks.length})</option>
+      ))}
+    </select>
+    {offMap > 0 && (
+      <span class="cmap-partial"
+            title="Online talks have no place to pin, and some records have no location recorded yet. Both are listed under the map rather than dropped.">
+        {plural(offMap, 'talk')} not on the map
+      </span>
+    )}
+  </div>
+
+  <ol class="cmap-list">
+    {pins.map((p, i) => (
+      <li data-c={i} style={`--h:${p.hue}`}>
+        <h3>{p.place} <span class="cmap-count">{plural(p.talks.length, 'talk')}</span></h3>
+        <ol hidden>
+          {p.talks.map((t) => (
+            <li>
+              <span class="cmap-when">{t.when}</span>
+              <span class="cmap-where">{t.url
+                ? <a href={t.url}>{t.title}</a>
+                : t.title}</span>
+              <span class="cmap-kind">{t.kindLabel}</span>
+              {t.details && <span class="cmap-role">{t.details}</span>}
+            </li>
+          ))}
+        </ol>
+      </li>
+    ))}
+  </ol>
+
+  {/* Outside .cmap-list on purpose: these are the talks the map cannot show, so
+      the picker must never hide them. */}
+  {offMap > 0 && (
+    <div class="cmap-off">
+      {online.length > 0 && (
+        <details>
+          <summary>{plural(online.length, 'talk')} online</summary>
+          {/* Not a pin, and not pretending to be one — an online talk happened
+              nowhere in particular, which is a fact worth keeping rather than
+              rounding to wherever I was sitting. */}
+          <ol>
+            {online.map((t) => (
+              <li>
+                <span class="cmap-when">{t.when}</span>
+                <span class="cmap-where">{t.url ? <a href={t.url}>{t.title}</a> : t.title}</span>
+                <span class="cmap-kind">{t.kindLabel}</span>
+              </li>
+            ))}
+          </ol>
+        </details>
+      )}
+      {(unplaced.length > 0 || unsettled.length > 0) && (
+        <details>
+          <summary>{plural(unplaced.length + unsettled.length, 'talk')} not placed yet</summary>
+          <p class="cmap-note">
+            Where these happened is recorded in <a href="https://github.com/nstarman/nstarman.github.io/issues/22">#22</a> and
+            not yet settled. {unsettled.length > 0 && (
+              <>Two carry a location written the old way — <code>TO, CA</code> reads
+              as California to a geocoder rather than Toronto — so they are listed
+              rather than pinned somewhere wrong.</>
+            )}
+          </p>
+          <ol>
+            {[...unsettled, ...unplaced].map((t) => (
+              <li>
+                <span class="cmap-when">{t.when}</span>
+                <span class="cmap-where">{t.url ? <a href={t.url}>{t.title}</a> : t.title}</span>
+                <span class="cmap-kind">{t.kindLabel}</span>
+                {t.location && <span class="cmap-role">recorded as “{t.location}”</span>}
+              </li>
+            ))}
+          </ol>
+        </details>
+      )}
+    </div>
+  )}
+</figure>
+
+<script>
+  import { wireAll } from '../lib/mappick.js';
+  wireAll();
+</script>

--- a/src/components/ConfMap.astro
+++ b/src/components/ConfMap.astro
@@ -47,9 +47,15 @@ const offMap = online.length + unsettled.length + unplaced.length;
 
     {/* Biggest first, so a place with one talk is never hidden under a place
         with eight — the pins are filled, and painting order is the only depth
-        an SVG has. */}
+        an SVG has.
+
+        --r carries its unit: CSS `r` is a length, and a unitless number is only
+        a length in a browser being generous. Chromium accepts it; Safari drops
+        the declaration, `r` computes to its initial 0, and every pin vanishes
+        while the land still draws — so it reads as an empty map rather than as
+        a broken rule, and survives a look in the wrong browser. */}
     {[...pins].sort((a, b) => b.r - a.r).map((pin) => (
-      <g class="cmap-pin" data-c={pins.indexOf(pin)} style={`--h:${pin.hue}; --r:${pin.r}`}>
+      <g class="cmap-pin" data-c={pins.indexOf(pin)} style={`--h:${pin.hue}; --r:${pin.r}px`}>
         {/* <title> is the native tooltip and the accessible name at once. */}
         <title>{pin.place} — {plural(pin.talks.length, 'talk')}</title>
         {/* `r` twice on purpose: the attribute is what a stylesheet-less render

--- a/src/lib/collabmap.js
+++ b/src/lib/collabmap.js
@@ -5,44 +5,19 @@
 // the papers we wrote while they were there, which is the part that makes it a
 // map of collaboration rather than of employment.
 //
-// Projection and geometry are resolved here rather than in the component, so
-// the page renders plain numbers and the maths is testable without a DOM.
+// Geometry is resolved here rather than in the component, so the page renders
+// plain numbers and the maths is testable without a DOM. The projection itself
+// lives in worldmap.js, shared with the conference map.
 
 import collaborators from '/config/collaborators.json';
 import places from '/config/places.json';
-import world from '../assets/world-equal-earth.json';
+import { map, project, toXY, spread, hueFor, KM_PER_UNIT, MAX_DRIFT_MILES, MAX_PIN_DRIFT }
+  from './worldmap.js';
 import { byType, venueUrl, links } from './data.js';
 
-export const map = {
-  width: world.width, height: world.height,
-  land: world.d, lakes: world.lakes,
-};
-
-const A1 = 1.340264, A2 = -0.081106, A3 = 0.000893, A4 = 0.003796;
-const M = Math.sqrt(3) / 2;
-
-/** Equal Earth (Šavrič, Patterson & Jenny 2018). Equal-area, so no country is
- *  drawn bigger than it is — which is the point of a map about where people are. */
-export function project(lon, lat) {
-  const l = (lon * Math.PI) / 180;
-  const p = (lat * Math.PI) / 180;
-  const th = Math.asin(M * Math.sin(p));
-  const th2 = th * th, th6 = th2 * th2 * th2;
-  const x = (2 * Math.sqrt(3) * l * Math.cos(th))
-    / (3 * (9 * A4 * th6 * th2 + 7 * A3 * th6 + 3 * A2 * th2 + A1));
-  const y = A4 * th6 * th2 * th + A3 * th6 * th + A2 * th2 * th + A1 * th;
-  return [x, y];
-}
-
-const [MAXX] = project(180, 0);
-const [, MAXY] = project(0, 90);
-const SCALE = world.width / (2 * MAXX);
-
-/** lon/lat -> the same user units the committed world path is drawn in. */
-export function toXY(lon, lat) {
-  const [x, y] = project(lon, lat);
-  return [(x + MAXX) * SCALE, (MAXY - y) * SCALE];
-}
+// Re-exported because the map's callers and tests have always reached for them
+// here, and where the maths lives is not their concern.
+export { map, project, toXY, KM_PER_UNIT, MAX_DRIFT_MILES, MAX_PIN_DRIFT };
 
 /** Papers we co-wrote, by the author's ORCID. */
 function papersByAuthor() {
@@ -70,73 +45,11 @@ function papersByAuthor() {
 const covers = (post, date) =>
   Boolean(post.start) && post.start <= date && (!post.end || post.end >= date);
 
-/** Kilometres per map unit: the map's height spans 180 degrees of latitude, and
- *  a degree of latitude is 111 km wherever you stand. */
-export const KM_PER_UNIT = 111 / (map.height / 180);
-
-/**
- * How far a pin may be moved from the place it stands for.
- *
- * Ten miles — city level. Written as a distance rather than a number of units
- * because the tolerance is a claim about the world, not about the drawing: at
- * this scale one unit is about 41 km, so three units was seventy-six miles and
- * put Case Western outside Cleveland.
- *
- * A pin is three units across, which is far wider than this, so stacked pins
- * now overlap almost exactly. That is the honest picture — the picker below the
- * map is what separates a crowd, not a lie about where people were.
- */
-// Nine and a half, not ten: coordinates are written to two decimals in the SVG,
-// which is a fifth of a mile of rounding on top of whatever the model decided.
-// The promise is about the pin on the screen, so the rounding comes out of the
-// budget rather than out of the promise.
-export const MAX_DRIFT_MILES = 9.5;
-export const MAX_PIN_DRIFT = (MAX_DRIFT_MILES * 1.609) / KM_PER_UNIT;
-const MAX_DRIFT = MAX_PIN_DRIFT;
-
-/**
- * Separate pins that share a coordinate, and no more than that.
- *
- * An earlier version clustered by proximity and then relaxed everything apart
- * until nothing touched. It produced a tidy map and a false one: pins drifted a
- * median of ten units and a maximum of twenty-five, which is nine degrees of
- * longitude — Columbia University came out somewhere in Ohio, and Case Western
- * left Cleveland. Overlapping pins are honest; misplaced ones are not, and a
- * map's first duty is to put things where they are.
- *
- * So only exact co-location is fixed, by fanning the stack into a small rosette
- * inside MAX_DRIFT. Institutions that are genuinely near each other — Harvard
- * and MIT, Princeton and the IAS — are drawn near each other, because they are.
- * The picker is what separates a crowd now.
- */
-function spread(pins) {
-  const at = new Map();
-  for (const pin of pins) {
-    const key = `${pin.x.toFixed(2)},${pin.y.toFixed(2)}`;
-    if (!at.has(key)) at.set(key, []);
-    at.get(key).push(pin);
-  }
-  for (const group of at.values()) {
-    if (group.length === 1) continue;
-    // Every member the same distance out, so the stack reads as a rosette
-    // rather than one pin with satellites.
-    const r = Math.min(MAX_DRIFT, 1.2 + group.length * 0.35);
-    group.forEach((pin, i) => {
-      const a = (2 * Math.PI * i) / group.length - Math.PI / 2;
-      pin.x += r * Math.cos(a);
-      pin.y += r * Math.sin(a);
-    });
-  }
-}
-
 /**
  * One entry per collaborator who can be put on the map at all: they have at
  * least one dated post at an institution with known coordinates.
  *
- * `hue` is a number, not a colour: the stylesheet decides how light to make it,
- * because a hue that reads on paper-white disappears on near-black. Hues are
- * spread by the golden angle so neighbours in the list are far apart on the
- * wheel however many people there turn out to be.
+ * `hue` comes from worldmap.js, spread by the golden angle.
  */
 export function collaboratorMap() {
   const papers = papersByAuthor();
@@ -176,7 +89,7 @@ export function collaboratorMap() {
   }
 
   people.sort((a, b) => a.name.localeCompare(b.name));
-  people.forEach((p, i) => { p.hue = Math.round((i * 137.508) % 360); });
+  people.forEach((p, i) => { p.hue = hueFor(i); });
   spread(people.flatMap((p) => p.pins));
   return people;
 }

--- a/src/lib/confmap.js
+++ b/src/lib/confmap.js
@@ -1,0 +1,109 @@
+// The conference map's render model.
+//
+// A pin is a place I have given a talk, run a workshop, or shown a poster; its
+// size is how many times. The list underneath is those talks, newest first.
+//
+// The unit here is the *place*, not the talk: eight visits to Cleveland are one
+// pin and eight lines, because a map answering "where have you spoken" is asking
+// about places. That is the one structural difference from the collaborator map,
+// where the unit is a person and the pins are their posts.
+//
+// Geometry is resolved here rather than in the component, so the page renders
+// plain numbers and the maths is testable without a DOM.
+
+import places from '/config/places.json';
+import { map, toXY, spread, hueFor } from './worldmap.js';
+import { byType, dateLabel, links } from './data.js';
+
+export { map };
+
+/** A talk with no venue. Deliberately not a pin: putting "Online" somewhere on
+ *  Earth would be inventing a fact, so it gets its own list instead (#22). */
+export const ONLINE = 'Online';
+
+/** How the CV's `kind` reads in a sentence about one talk. */
+const KIND = {
+  invited: 'invited talk',
+  contributed: 'contributed',
+  poster: 'poster',
+  seminar: 'seminar',
+  organizer: 'organised',
+  attended: 'attended',
+};
+
+/** Area, not radius, carries the count — a place with four talks should look
+ *  four times as big, and doubling the radius would make it sixteen. */
+export const radius = (n) => Number((2.8 * Math.sqrt(n)).toFixed(2));
+
+function talkOf(item) {
+  const event = (links(item) ?? []).find((l) => l.rel === 'event');
+  return {
+    id: item.id,
+    date: String(item.date.start),
+    when: dateLabel(item, { month: true }),
+    title: item.title,
+    kind: item.kind,
+    kindLabel: KIND[item.kind] ?? item.kind,
+    // What the talk was about, where the record says. Never the location — that
+    // is the pin's job, and printing it twice is how the old records read.
+    details: typeof item.details === 'string' ? item.details : null,
+    url: event?.url ?? null,
+  };
+}
+
+const newestFirst = (a, b) => b.date.localeCompare(a.date);
+
+/**
+ * Every presentation, sorted into the four things it can be.
+ *
+ * `pins` are the ones with a settled, resolvable location. `online` had no
+ * venue. `unsettled` still carry a location string the geocoder refuses —
+ * `TO, CA` reads as California, so it is left off rather than guessed at.
+ * `undated` have no location recorded yet at all.
+ *
+ * Every talk lands in exactly one of the four, and the page says so: a map that
+ * quietly drops seventeen talks is worse than one that admits to them.
+ */
+export function conferenceMap() {
+  const online = [];
+  const unsettled = [];
+  const unplaced = [];
+  const here = new Map();
+
+  for (const item of byType('presentation')) {
+    const talk = talkOf(item);
+    const loc = item.location;
+    if (!loc) { unplaced.push(talk); continue; }
+    if (loc === ONLINE) { online.push(talk); continue; }
+    const at = places.places[loc];
+    if (!at) { unsettled.push({ ...talk, location: loc }); continue; }
+    if (!here.has(loc)) here.set(loc, []);
+    here.get(loc).push(talk);
+  }
+
+  const pins = [...here.entries()]
+    // Alphabetical, because the picker under the map is a list of names and a
+    // reader looking for Toronto should find it where T belongs.
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([place, talks], i) => {
+      const { lat, lon } = places.places[place];
+      const [x, y] = toXY(lon, lat);
+      talks.sort(newestFirst);
+      return { place, lat, lon, x, y, talks, r: radius(talks.length), hue: hueFor(i) };
+    });
+
+  spread(pins);
+  online.sort(newestFirst);
+  unsettled.sort(newestFirst);
+  unplaced.sort(newestFirst);
+
+  return {
+    pins,
+    online,
+    unsettled,
+    unplaced,
+    talks: pins.reduce((n, p) => n + p.talks.length, 0),
+    total: online.length + unsettled.length + unplaced.length
+      + pins.reduce((n, p) => n + p.talks.length, 0),
+  };
+}

--- a/src/lib/mappick.js
+++ b/src/lib/mappick.js
@@ -1,0 +1,94 @@
+// The picking, hovering and dimming shared by the maps on this site.
+//
+// Progressive enhancement, and only that: with no JavaScript every pin, every
+// trajectory and every name is already on the page, which is the honest default
+// anyway. What this adds is the ability to pull one entry out of thirty.
+//
+// It toggles `hidden` rather than a class so the effect is in the DOM rather
+// than only in the paint — a screen reader is told the same thing the eye is.
+//
+// Written against the markup both maps share — a `.cmap` figure containing
+// `.cmap-pin`/`.cmap-trail` elements, a `.cmap-who` select, and a `.cmap-list`
+// whose items carry the same `data-c` — rather than against either one, so the
+// conference map got this behaviour without a second copy of it.
+
+function wire(fig) {
+  const pick = fig.querySelector('.cmap-who');
+  if (!pick) return;
+  const all = (sel) => [...fig.querySelectorAll(sel)];
+  const list = fig.querySelector('.cmap-list');
+
+  const show = (only) => {
+    const mine = (el) => only === '' || el.dataset.c === only;
+    for (const el of all('.cmap-pin, .cmap-trail')) el.style.display = mine(el) ? '' : 'none';
+    // Showing everything means the map, and only the map: a roster of thirty
+    // entries under it is the wall of text the picker exists to avoid.
+    if (list) {
+      list.hidden = only === '';
+      for (const li of all('.cmap-list > li')) {
+        li.hidden = !mine(li);
+        // The detail belongs to whoever was asked for.
+        const detail = li.querySelector('ol');
+        const note = li.querySelector('.cmap-note');
+        // Only the one asked for; the others are hidden anyway, and content
+        // inside a hidden element should not be pretending to be visible.
+        const open = only !== '' && mine(li);
+        if (detail) detail.hidden = !open;
+        if (note) note.hidden = !open;
+      }
+    }
+    fig.dataset.only = only;
+  };
+
+  // Hover and keyboard linking between the two halves. Set on the elements
+  // rather than expressed as a rule keyed off the figure: CSS cannot say "this
+  // element's data-c matches its ancestor's data-hover" without one rule per
+  // entry, and the version that dimmed everything and lit the match back up did
+  // not survive contact with a real browser. This does one thing and can be
+  // checked by reading it back.
+  const dimmable = () => all('.cmap-pin, .cmap-trail, .cmap-list > li');
+  const mark = (el) => {
+    const owner = el?.closest?.('[data-c]');
+    const only = owner?.dataset.c;
+    for (const e of dimmable()) {
+      // Trails carry their own resting opacity, so restoring means clearing the
+      // override rather than writing 1 over the top of it.
+      e.style.opacity = only === undefined || e.dataset.c === only ? '' : '.12';
+    }
+    if (only === undefined) delete fig.dataset.hover;
+    else fig.dataset.hover = only;
+  };
+
+  pick.addEventListener('change', () => show(pick.value));
+  show('');
+
+  fig.addEventListener('pointerover', (e) => mark(e.target));
+  fig.addEventListener('pointerleave', () => mark(null));
+  fig.addEventListener('focusin', (e) => mark(e.target));
+  fig.addEventListener('focusout', () => mark(null));
+
+  // Clicking a pin or a trail picks it, which is what pointing at something on
+  // a map and pressing it ought to do. Hover deliberately does not: sweeping
+  // the cursor across eighty-five pins would rebuild the list under the reader
+  // several times a second. Hover previews by dimming the others; the click
+  // commits.
+  fig.addEventListener('click', (e) => {
+    const owner = e.target.closest?.('.cmap-pin, .cmap-trail');
+    if (!owner) return;
+    pick.value = owner.dataset.c;
+    show(pick.value);
+    // Selecting hides everything else, so the thing being pointed at is no
+    // longer under the cursor and the dimming has nothing left to say.
+    mark(null);
+  });
+}
+
+/** Wire every map on the page, once each. Both components import this, and
+ *  Astro serves one copy of the module however many of them there are. */
+export function wireAll() {
+  for (const fig of document.querySelectorAll('.cmap')) {
+    if (fig.dataset.wired) continue;
+    fig.dataset.wired = '1';
+    wire(fig);
+  }
+}

--- a/src/lib/worldmap.js
+++ b/src/lib/worldmap.js
@@ -1,0 +1,106 @@
+// The world, and the geometry every map on this site shares.
+//
+// Extracted from collabmap.js when a second map arrived (the conference map,
+// #22): the projection is a published formula with a test asserting it matches
+// the paper, and a second copy of it is a second thing that can drift out of
+// agreement with the first.
+//
+// Inline SVG on a committed Equal Earth outline — no tiles, so no third party
+// sees a visitor's viewport, and the whole thing works offline.
+
+import world from '../assets/world-equal-earth.json';
+
+export const map = {
+  width: world.width, height: world.height,
+  land: world.d, lakes: world.lakes,
+};
+
+const A1 = 1.340264, A2 = -0.081106, A3 = 0.000893, A4 = 0.003796;
+const M = Math.sqrt(3) / 2;
+
+/** Equal Earth (Šavrič, Patterson & Jenny 2018). Equal-area, so no country is
+ *  drawn bigger than it is — which is the point of a map about where things are. */
+export function project(lon, lat) {
+  const l = (lon * Math.PI) / 180;
+  const p = (lat * Math.PI) / 180;
+  const th = Math.asin(M * Math.sin(p));
+  const th2 = th * th, th6 = th2 * th2 * th2;
+  const x = (2 * Math.sqrt(3) * l * Math.cos(th))
+    / (3 * (9 * A4 * th6 * th2 + 7 * A3 * th6 + 3 * A2 * th2 + A1));
+  const y = A4 * th6 * th2 * th + A3 * th6 * th + A2 * th2 * th + A1 * th;
+  return [x, y];
+}
+
+const [MAXX] = project(180, 0);
+const [, MAXY] = project(0, 90);
+const SCALE = world.width / (2 * MAXX);
+
+/** lon/lat -> the same user units the committed world path is drawn in. */
+export function toXY(lon, lat) {
+  const [x, y] = project(lon, lat);
+  return [(x + MAXX) * SCALE, (MAXY - y) * SCALE];
+}
+
+/** Kilometres per map unit: the map's height spans 180 degrees of latitude, and
+ *  a degree of latitude is 111 km wherever you stand. */
+export const KM_PER_UNIT = 111 / (map.height / 180);
+
+/**
+ * How far a pin may be moved from the place it stands for.
+ *
+ * Ten miles — city level. Written as a distance rather than a number of units
+ * because the tolerance is a claim about the world, not about the drawing: at
+ * this scale one unit is about 41 km, so three units was seventy-six miles and
+ * put Case Western outside Cleveland.
+ *
+ * A pin is three units across, which is far wider than this, so stacked pins
+ * now overlap almost exactly. That is the honest picture — the picker below the
+ * map is what separates a crowd, not a lie about where things were.
+ */
+// Nine and a half, not ten: coordinates are written to two decimals in the SVG,
+// which is a fifth of a mile of rounding on top of whatever the model decided.
+// The promise is about the pin on the screen, so the rounding comes out of the
+// budget rather than out of the promise.
+export const MAX_DRIFT_MILES = 9.5;
+export const MAX_PIN_DRIFT = (MAX_DRIFT_MILES * 1.609) / KM_PER_UNIT;
+
+/**
+ * Separate pins that share a coordinate, and no more than that.
+ *
+ * An earlier version clustered by proximity and then relaxed everything apart
+ * until nothing touched. It produced a tidy map and a false one: pins drifted a
+ * median of ten units and a maximum of twenty-five, which is nine degrees of
+ * longitude — Columbia University came out somewhere in Ohio, and Case Western
+ * left Cleveland. Overlapping pins are honest; misplaced ones are not, and a
+ * map's first duty is to put things where they are.
+ *
+ * So only exact co-location is fixed, by fanning the stack into a small rosette
+ * inside MAX_PIN_DRIFT. Institutions that are genuinely near each other —
+ * Harvard and MIT, Princeton and the IAS — are drawn near each other, because
+ * they are. The picker is what separates a crowd now.
+ */
+export function spread(pins) {
+  const at = new Map();
+  for (const pin of pins) {
+    const key = `${pin.x.toFixed(2)},${pin.y.toFixed(2)}`;
+    if (!at.has(key)) at.set(key, []);
+    at.get(key).push(pin);
+  }
+  for (const group of at.values()) {
+    if (group.length === 1) continue;
+    // Every member the same distance out, so the stack reads as a rosette
+    // rather than one pin with satellites.
+    const r = Math.min(MAX_PIN_DRIFT, 1.2 + group.length * 0.35);
+    group.forEach((pin, i) => {
+      const a = (2 * Math.PI * i) / group.length - Math.PI / 2;
+      pin.x += r * Math.cos(a);
+      pin.y += r * Math.sin(a);
+    });
+  }
+}
+
+/** Hues spread by the golden angle, so neighbours in a list are far apart on
+ *  the wheel however many entries there turn out to be. A number, not a colour:
+ *  the stylesheet decides how light to make it, because a hue that reads on
+ *  paper-white disappears on near-black. */
+export const hueFor = (i) => Math.round((i * 137.508) % 360);

--- a/src/pages/research.astro
+++ b/src/pages/research.astro
@@ -13,13 +13,13 @@ import ConfMap from '../components/ConfMap.astro';
         {/* The cones say it; a tag repeating them said it twice. */}
         <p class="lede">🚧&nbsp;Under Construction.&nbsp;🚧</p>
 
-        <h3 id="conferences" class="cmap-head">Conferences</h3>
-        <p class="lede">Every talk, poster and workshop, and where it happened:</p>
-        <ConfMap />
-
         <h3 id="collaborators" class="cmap-head">Collaborators</h3>
         <p class="lede">An incomplete record of people I have written a paper with:</p>
         <CollabMap />
+
+        <h3 id="conferences" class="cmap-head">Conferences</h3>
+        <p class="lede">Every talk, poster and workshop, and where it happened:</p>
+        <ConfMap />
       </div>
     </section>
   </main>

--- a/src/pages/research.astro
+++ b/src/pages/research.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/Base.astro';
 import CollabMap from '../components/CollabMap.astro';
+import ConfMap from '../components/ConfMap.astro';
 ---
 <Base title="Research — Nathaniel Starkman">
   <main>
@@ -11,6 +12,10 @@ import CollabMap from '../components/CollabMap.astro';
         </div>
         {/* The cones say it; a tag repeating them said it twice. */}
         <p class="lede">🚧&nbsp;Under Construction.&nbsp;🚧</p>
+
+        <h3 id="conferences" class="cmap-head">Conferences</h3>
+        <p class="lede">Every talk, poster and workshop, and where it happened:</p>
+        <ConfMap />
 
         <h3 id="collaborators" class="cmap-head">Collaborators</h3>
         <p class="lede">An incomplete record of people I have written a paper with:</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -989,3 +989,44 @@ nav ul a.on:hover{color:var(--accent); border-color:var(--accent)}
 
 /* A pin is pressable, so it should look it. */
 .cmap-pin, .cmap-trail{cursor:pointer}
+
+/* ── The conference map ──────────────────────────────────────────────────────
+   Shares every class with the collaborator map above; what follows is only the
+   handful of things a map of talks needs and a map of people does not. */
+
+/* A conference pin's radius carries its count, so it comes from the model as
+   --r rather than from a fixed rule. Written back through CSS because the
+   collaborator map's `r` above would otherwise flatten every pin to one size —
+   the `r` attribute in the markup is still what a stylesheet-less render uses.
+   Part-transparent so overlapping cities read as overlapping rather than as one
+   blob, which is what Cambridge and New York do at this scale. */
+.cmap--conf .cmap-pin circle{r:var(--r); fill:oklch(.55 .16 var(--h) / .72)}
+.cmap--conf .cmap-pin:hover circle,
+.cmap--conf .cmap-pin:focus-visible circle,
+.cmap--conf[data-hover] .cmap-pin:not([style*="opacity"]) circle{
+  r:calc(var(--r) * 1.45); fill-opacity:1
+}
+@media (max-width:44rem){
+  /* The phone rule above doubles a three-unit pin; the same generosity here,
+     applied to a size that already varies. */
+  .cmap--conf .cmap-pin circle{r:calc(var(--r) * 1.7); stroke-width:3}
+}
+
+/* Filled and unstroked, because a conference pin is: a 2px stroke on a circle
+   this small is most of the circle, and the two keys stopped being comparable. */
+.cmap-key--conf circle{fill:var(--ink-mute); stroke:none}
+
+.cmap-count{font-family:var(--mono); font-size:.7rem; color:var(--ink-faint); font-weight:400}
+.cmap-kind{display:inline-block; margin-left:.4rem; font-size:.68rem; color:var(--ink-mute);
+  text-transform:lowercase; font-variant:small-caps; letter-spacing:.02em}
+
+/* The talks the map cannot show. Collapsed, because they are a footnote to it —
+   but present, because dropping them would make the map read as complete. */
+.cmap-off{margin:1.2rem 0 0; display:grid; gap:.5rem}
+.cmap-off details{border-left:2px solid var(--ink-faint); padding:0 0 0 .7rem}
+.cmap-off summary{font-size:.8rem; color:var(--ink-2); cursor:pointer}
+.cmap-off summary:hover, .cmap-off summary:focus-visible{color:var(--accent)}
+.cmap-off ol{list-style:none; margin:.5rem 0 0; padding:0; display:grid; gap:.5rem}
+.cmap-off ol li{font-size:.8rem; line-height:1.45}
+.cmap-off .cmap-note{margin:.5rem 0 0}
+.cmap-off code{font-size:.9em}

--- a/tests/confmap.test.js
+++ b/tests/confmap.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { conferenceMap, radius, ONLINE, map } from '../src/lib/confmap.js';
 import { toXY, KM_PER_UNIT, MAX_DRIFT_MILES } from '../src/lib/worldmap.js';
 import { byType } from '../src/lib/data.js';
+import { readFileSync } from 'node:fs';
 
 const cmap = conferenceMap();
 
@@ -50,6 +51,17 @@ describe('the conference map', () => {
     for (const pin of cmap.pins) {
       expect(pin.place).toMatch(/^[^,]+, (?:[A-Z]{2}, (?:USA|Canada)|[^,]+)$/);
     }
+  });
+
+  it('writes the pin radius with a unit', () => {
+    // The bug this guards: `--r:7.92` with no unit. CSS `r` takes a length, and
+    // a bare number is not one — Chromium accepts it anyway, Safari drops the
+    // declaration, `r` computes to its initial 0, and every pin vanishes while
+    // the land still draws. It reads as an empty map, not as a broken rule, so
+    // it survives a look in the wrong browser.
+    const src = readFileSync(new URL('../src/components/ConfMap.astro', import.meta.url), 'utf8');
+    expect(src).toMatch(/--r:\$\{pin\.r\}px/);
+    expect(src).not.toMatch(/--r:\$\{pin\.r\}[^p]/);
   });
 
   it('sizes a pin by area, so counts read honestly', () => {

--- a/tests/confmap.test.js
+++ b/tests/confmap.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { conferenceMap, radius, ONLINE, map } from '../src/lib/confmap.js';
+import { toXY, KM_PER_UNIT, MAX_DRIFT_MILES } from '../src/lib/worldmap.js';
+import { byType } from '../src/lib/data.js';
+
+const cmap = conferenceMap();
+
+describe('the conference map', () => {
+  it('accounts for every presentation exactly once', () => {
+    // The property that matters most: a map that silently drops a talk is
+    // worse than one that says it cannot place it.
+    const all = byType('presentation');
+    expect(cmap.total).toBe(all.length);
+
+    const ids = [
+      ...cmap.pins.flatMap((p) => p.talks.map((t) => t.id)),
+      ...cmap.online.map((t) => t.id),
+      ...cmap.unsettled.map((t) => t.id),
+      ...cmap.unplaced.map((t) => t.id),
+    ];
+    expect(ids.length).toBe(all.length);
+    expect(new Set(ids).size).toBe(all.length);
+  });
+
+  it('places every pin inside the map', () => {
+    const out = cmap.pins.filter((p) => p.x < 0 || p.x > map.width || p.y < 0 || p.y > map.height);
+    expect(out).toEqual([]);
+  });
+
+  it('never draws a pin far from where the place actually is', () => {
+    for (const pin of cmap.pins) {
+      const [tx, ty] = toXY(pin.lon, pin.lat);
+      const miles = (Math.hypot(pin.x - tx, pin.y - ty) * KM_PER_UNIT) / 1.609;
+      expect(miles).toBeLessThanOrEqual(MAX_DRIFT_MILES + 0.01);
+    }
+  });
+
+  it('never puts an online talk on the map', () => {
+    // "Online" is not a place, and the whole point of #22's note about it is
+    // that it must not become a pin somewhere on Earth.
+    expect(cmap.online.length).toBeGreaterThan(0);
+    for (const pin of cmap.pins) expect(pin.place).not.toBe(ONLINE);
+  });
+
+  it('refuses a location a geocoder would misread, rather than guessing', () => {
+    // `TO, CA` is Toronto, Ontario; a geocoder reads CA as California. Issue #22
+    // calls this the one that silently produces a plausible-looking wrong map.
+    // Until the string is settled the talk is listed, not pinned.
+    for (const t of cmap.unsettled) expect(t.location).toBeTruthy();
+    for (const pin of cmap.pins) {
+      expect(pin.place).toMatch(/^[^,]+, (?:[A-Z]{2}, (?:USA|Canada)|[^,]+)$/);
+    }
+  });
+
+  it('sizes a pin by area, so counts read honestly', () => {
+    // Doubling the radius would quadruple the ink for twice the talks.
+    expect(radius(4) / radius(1)).toBeCloseTo(2, 6);
+    expect(radius(9) / radius(1)).toBeCloseTo(3, 6);
+    for (const pin of cmap.pins) expect(pin.r).toBe(radius(pin.talks.length));
+  });
+
+  it('gives every place a different hue', () => {
+    const hues = cmap.pins.map((p) => p.hue);
+    expect(new Set(hues).size).toBe(hues.length);
+  });
+
+  it('lists a place’s talks newest first, and the places alphabetically', () => {
+    const names = cmap.pins.map((p) => p.place);
+    expect([...names].sort((a, b) => a.localeCompare(b))).toEqual(names);
+    for (const pin of cmap.pins) {
+      const dates = pin.talks.map((t) => t.date);
+      expect([...dates].sort().reverse()).toEqual(dates);
+    }
+  });
+
+  it('separates places that land on the same coordinate', () => {
+    const seen = new Set(cmap.pins.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`));
+    expect(seen.size).toBe(cmap.pins.length);
+  });
+
+  it('carries what each talk needs to render itself', () => {
+    for (const pin of cmap.pins) {
+      for (const t of pin.talks) {
+        expect(t.title).toBeTruthy();
+        expect(t.when).toMatch(/\d{4}/);
+        expect(t.kindLabel).toBeTruthy();
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes part of #22. Every location came from a public record — the source is on each line.

**13 of 65 presentations carried a location → 53**, eight of the original 13 rewritten because they were the strings the issue body flags as unusable. Then the map those locations exist for: a **Conferences** section on the Research tab.

## Applied

**2016–2019**
- [x] `cornell-classe-summer-seminar-talk` 2016-08 → **Ithaca, NY, USA** · CLASSE is Cornell's; your own `nsf-reu-classe-participant-at-cornell` position record already says Ithaca, NY, USA
- [x] `dwarf-galaxies-on-the-shoulders-of-giants` 2017-06 → **Cleveland, OH, USA** · [CWRU Astronomy, 5–8 June 2017](https://astroweb.case.edu/dwarfs2017/)
- [x] `cwru-astronomy-summer-seminar-talk` 2017-08 → **Cleveland, OH, USA**
- [x] `cwru-physics-seminar-talk` 2017-10 → **Cleveland, OH, USA**
- [x] `cosmology-overview-at-cwru-origins-talk` 2017 → **Cleveland, OH, USA**
- [x] `cwru-source-intersections-poster` 2018-05 → **Cleveland, OH, USA**
- [x] `the-standard-model-at-50-years` 2018-06 → **Cleveland, OH, USA** · [the symposium's own page is on case.edu](https://artsci.case.edu/smat50/)
- [x] `comscicon-canada-2019` 2019-07 · `Hamilton, CA` → **Hamilton, ON, Canada** · [McMaster University, 18–20 July 2019](https://www.science.mcmaster.ca/sis/news-events/news-events/804-comsciconcan-communicating-science-conference.html) — the string the issue body flags as the silent-wrong-map case
- [x] `great-lakes-cosmology-workshop-talk` 2019-08 → **Rochester, NY, USA** · [GLCW12, Rochester Institute of Technology, 6–8 Aug 2019](https://sites.google.com/view/glcw12/home)
- [x] `5th-gaia-challenge-conference-talk` 2019-09 → **Paris, France** · [GC5, Institut d'Astrophysique de Paris, 9–13 Sept 2019](https://astrowiki.surrey.ac.uk/doku.php?id=gc5)
- [x] `5th-gaia-challenge-conference-talk-2` 2019-09 → **Paris, France** · same meeting
- [x] `astronomy-11` 2019-10 · `TO, CA` → **Toronto, ON, Canada** · [.Astronomy 11, Chestnut Conference Centre, 22–25 Oct 2019](https://dotastronomy.com/events/eleven/)
- [x] `30th-texas-symposium-on-relativistic-astrophysics-talk` 2019-12 → **Portsmouth, UK** · [University of Portsmouth and the Guildhall, 15–20 Dec 2019](https://www.icg.port.ac.uk/2019/01/30th-texas-symposium-on-relativistic-astrophysics-in-portsmouth-this-december/)
**2020–2023**
- [x] `comscicon-gta-2020` 2020-07 · **Online** — already correct, listed for completeness
- [x] `stsci-2020-the-local-group-assembly-and-evolution-symposium` 2020-08 → **Online** · [STScI's first fully virtual symposium, moved online for COVID, 31 Aug – 4 Sept 2020](https://www.stsci.edu/contents/newsletters/2020-volume-37-issue-02/stscis-2020-virtual-symposium-the-local-group-assembly-evolution)
- [x] `casca-agm-poster` 2021-05 → **Online** · [CASCA 2021 ran virtually on Hopin, hosted by Guelph, 12–15 May](https://www.casca2021.uoguelph.ca/)
- [x] `casca-agm-poster-2` 2021-05 → **Online** · same meeting
- [x] `aas-2021-talk` 2021-06 → **Online** · [AAS 238 was moved from Anchorage to virtual](https://aas.org/posts/news/2021/01/238th-aas-meeting-goes-virtual), 7–9 June 2021
- [x] `cats-2022` 2022-10 → **Pasadena, CA, USA** · [Streams22 at the Carnegie Observatories, 31 Oct – 4 Nov 2022](https://aas.org/events/2022-07/streams-22-community-atlas-tidal-streams)
- [x] `aas-2023-talk` 2023-01 → **Seattle, WA, USA** · [AAS 241, Washington State Convention Center, 8–12 Jan 2023](https://aas.org/meetings/aas241)
- [x] `cita-seminar` 2023-01 → **Toronto, ON, Canada**
- [x] `the-future-of-astrophysical-data` 2023-02 → **New York, NY, USA** · [Flatiron Institute](https://indico.flatironinstitute.org/event/3466/) — the string `NYC, USA` is currently sitting in `details`, not `location` (see the note at the end)
- [x] `iaus379-dynamical-masses-of-local-group-galaxies-poster` 2023-03 → **Potsdam, Germany** · [AIP, Telegrafenberg, 20–24 Mar 2023](https://meetings.aip.de/iaus379/)
- [x] `astropy-conference-talk` 2023-05 → **Cambridge, MA, USA** · [the 2023 coordination meeting was the MIT meeting](https://github.com/astropy/astropy/wiki/Meetings)
- [x] `desc-sprint-week` 2023-10 → **Pittsburgh, PA, USA** · [2023 DESC Sprint Week, Carnegie Mellon, 16–20 Oct 2023](https://www.lsst.org/content/2023-october-16-20-2023-desc-sprint-week-carnegie-mellon-university)
**2024–2026**
- [x] `division-on-dynamical-astronomy-55-talk` 2024-05 → **Toronto, ON, Canada** · [DDA 55, Myhal Centre, University of Toronto, 12–17 May 2024](https://dda.aas.org/meetings/2024)
- [x] `from-jax-to-galax` 2024-05 · `TO, CA` → **Toronto, ON, Canada** · [held inside GC&TT at the UofT Department of Statistics, 28–31 May 2024](https://physics.mcmaster.ca/~reinacam/gcandtidaltails24/) — the McMaster URL is the organiser's homepage, not the venue
- [x] `globular-clusters-and-their-tidal-tails-talk` 2024-05 → **Toronto, ON, Canada** · same meeting
- [x] `streams-24-the-theory-edition-talk` 2024-08 → **Durham, UK** · [Durham University, 5–9 Aug 2024](https://sophialilleengen.me/organising/streams24/)
- [x] `cwru-seminar` 2024-10 → **Cleveland, OH, USA** · [the department's event page](https://physics.case.edu/events/nathaniel-starkman-mit/)
- [x] `jaxtronomy-workshop` 2024-10 · `NYC, USA` → **New York, NY, USA** · [Simons Foundation](https://www.simonsfoundation.org/event/jaxtronomy/)
- [x] `gaia-hackathon-2` 2025-01 · `MIT, USA` → **Cambridge, MA, USA** · [gaiadr3hack.mit.edu](https://gaiadr3hack.mit.edu) — institution, not a place
- [x] `dark-seminar-copenhagen-2` 2025-03 → **Copenhagen, Denmark**
- [x] `dda-56` 2025-05 → **Atlanta, GA, USA** · [56th DDA annual meeting](https://dda.aas.org/meetings/56th%20Annual%20Meeting%20-%20Atlanta%2C%20Georgia%2C%20USA)
- [x] `division-of-dynamical-astronomy-56` 2025-05 · `GIT, USA` → **Atlanta, GA, USA** · same meeting, Georgia Tech — institution, not a place
- [x] `astropy-coordination-meeting` 2025-06 · `Santa Cruz, USA` → **Santa Cruz, CA, USA** · [the 2025 meeting is the UCSC meeting](https://github.com/astropy/astropy/wiki/Meetings)
- [x] `cca-software-seminar-nyc` 2025-09 → **New York, NY, USA**
- [x] `cosmology-2025-talk` 2025-09 → **Portoferraio, Italy** · [Hotel Hermitage, La Biodola, Elba, 7–13 Sept 2025](https://indico.global/event/7910). La Biodola is a hamlet of Portoferraio; say **Elba, Italy** instead if you would rather the map read as the island
- [x] `mki-journal-club-talk` 2025-09 → **Cambridge, MA, USA**
- [x] `princeton-thunch-seminar-princeton` 2025-09 → **Princeton, NJ, USA**
- [x] `dark-seminar-copenhagen` 2025-10 → **Copenhagen, Denmark**
- [x] `iaus-43-talk` 2025-10 → **Córdoba, Spain** · [IAUS 403, *The Hidden Beauty of the Galactic Outskirts*, 6–10 Oct 2025](https://www.iausymposium403.com/)
- [x] `texas-a-m-seminar-texas` 2025-10 → **College Station, TX, USA**
- [x] `tevpa-talk` 2025-11 → **Valencia, Spain** · [Fundación Bancaja / ADEIT, 3–7 Nov 2025](https://indico.ific.uv.es/event/7986/)
- [x] `tevpa-valencia` 2025-11 → **Valencia, Spain** · same meeting
- [x] `gaia-hackathon` 2026-01 · `MIT, USA` → **Cambridge, MA, USA**
- [x] `cwru-seminar-cleveland` 2026-02 → **Cleveland, OH, USA**
- [x] `dark-seminar-talk` 2026-06 → **Copenhagen, Denmark**
- [x] `eas-26-s10-lausanne` 2026-06 → **Lausanne, Switzerland** · [EAS 2026, SwissTech Convention Centre, 29 June – 3 July 2026](https://eas.unige.ch/EAS2026/call.jsp)
- [x] `near-field-cosmology-in-the-era-of-big-data-talk` 2026-07 → **Toronto, ON, Canada** · [Fields Institute, 222 College St, 20–24 July 2026](http://www.fields.utoronto.ca/activities/26-27/Nearfieldcosmology)
- [x] `astrophysics-and-space-science-in-marche-iii-big-bang-big-stars-big-computers` 2026-08 · **Jesi, Italy** — already correct
- [x] `marche-iii-big-bang-big-stars-big-computers-jesi` 2026-08 → **Jesi, Italy** · same meeting
- [x] `new-frontiers-in-cosmology-talk` 2026-08 → **A Coruña, Spain** · [UDC Rectorate, 10–14 Aug 2026](https://www.fundacion.udc.es/cosmology-conference-coruna-2026/)

## The format

`City, ST, Country` for the US and Canada — the shape `education` and `position` already use (`Cleveland, OH, USA`, `Toronto, ON, Canada`) — and `City, Country` elsewhere. `Online` where there was no venue.

That is what settles the ambiguity the issue opens with: `Hamilton, ON, Canada` and `Toronto, ON, Canada` can no longer be read as California, and no value is an institution acronym any more.

## The eight that were already wrong

```
Hamilton, CA   -> Hamilton, ON, Canada     comscicon-canada-2019
TO, CA         -> Toronto, ON, Canada      astronomy-11
TO, CA         -> Toronto, ON, Canada      from-jax-to-galax
NYC, USA       -> New York, NY, USA        jaxtronomy-workshop
MIT, USA       -> Cambridge, MA, USA       gaia-hackathon-2
MIT, USA       -> Cambridge, MA, USA       gaia-hackathon
GIT, USA       -> Atlanta, GA, USA         division-of-dynamical-astronomy-56
Santa Cruz, USA-> Santa Cruz, CA, USA      astropy-coordination-meeting
```

`from-jax-to-galax` is worth a second look: its link points at a McMaster URL, but that is the organiser's homepage — [the meeting itself](https://physics.mcmaster.ca/~reinacam/gcandtidaltails24/) ran at the UofT Department of Statistics, so Toronto is right for a reason the link does not show.

## Where the locations came from

| kind | source |
|---|---|
| conferences and workshops | the meeting's own site, or the society's meeting page |
| the COVID years | the organiser's announcement that the meeting moved online — AAS 238, CASCA 2021, the STScI symposium |
| institutional seminars | the host institution's city |
| Astropy meetings | [the project's Meetings wiki](https://github.com/astropy/astropy/wiki/Meetings), which names each year's meeting by its host |

## The map

A second map on the Research tab, below Collaborators, built from the same committed Equal Earth outline — no tiles, so no third party sees a visitor's viewport and it works offline, per the rendering constraints in the issue.

The unit is the **place**, not the talk: eight visits to Cleveland are one pin and eight lines, because a map answering "where have you spoken" is asking about places. That is the one structural difference from the collaborator map, where the unit is a person and the pins are their posts.

A pin's **area** is its count, not its radius — twice the radius is four times the talks, so 25 pins carry 48 talks without a place with eight merely looking a bit bigger than a place with one. Pins are part-transparent, because Cambridge and New York overlap at this scale and two overlapping circles should read as two.

**Nothing is dropped.** The map covers 48 of the 65 talks, and the other 17 are listed under it rather than quietly missing:

| | |
|---|---|
| 48 | pinned |
| 5 | online — listed, never pinned. "Online" is not somewhere on Earth, and rounding it to wherever I was sitting would be inventing a fact |
| 2 | still written the old way, named with the string they carry |
| 10 | no location recorded yet — the unticked items on the issue |

The two unsettled ones are the reason that is a list and not a guess. `TO, CA` is Toronto; a geocoder reads `CA` as California and puts the pin 3,500 km away without ever looking wrong. It stays off the map until #22 settles it.

## Coordinates

`config/places.json` gains 25 entries, resolved once with `scripts/geocode-places.mjs` and committed, so the site and CI never call a geocoder — the arrangement #65 set up for collaborator institutions, now one file so the two maps cannot disagree about where Cambridge is.

The script grew a filter: it resolves a location only if it matches the settled format, so `TO, CA` and `Boston, USA` are reported and skipped rather than turned into a confident wrong pin.

Two answers needed correcting by hand, which is why the script writes down what the geocoder thought it found:

```
Durham, UK           County Durham centroid, 17 km from the city -> Durham
Santa Cruz, CA, USA  Santa Cruz County centroid, 9 km            -> Santa Cruz
```

## Shared, not copied

The Equal Earth projection, the drift budget and the co-location rosette move from `collabmap.js` to `src/lib/worldmap.js`; the picker, hover and dim behaviour moves from inline in `CollabMap.astro` to `src/lib/mappick.js`, which wires every `.cmap` on the page.

The projection is a published formula with a test asserting it matches the paper, and a second copy is a second thing that can drift out of agreement with the first. `collabmap.js` re-exports what it always exported, so its 16 tests pass unchanged — which is the evidence the extraction changed no behaviour.

## Verification

`npm test` — **167 unit tests** (11 new for the conference map), schema, BibTeX, build, a11y and links all pass. `npm run build:pdf` still gives one page for the 1-page CV and two for the 2-page one.

`location` already feeds the CV's right-hand column via `trailing()` in `src/lib/cvmodel.js`, so this is visible in the PDFs as well as on the site: the talks in the np CV that print a place go from 8 to 36.

Checked in the browser at desktop and mobile, in both themes: no console errors, no horizontal overflow, pins scale up on small screens, and the two maps' pickers work independently — picking Toronto shows one pin and six talks while the collaborator map below is untouched.

The new tests assert the things that would make the map lie: every presentation lands in exactly one of the four buckets and none is dropped, no pin sits more than 9.5 miles from its coordinate, no online talk becomes a pin, and no pin carries a location a geocoder would misread.

One more guards a bug this PR shipped and fixed. The pin radius came from `--r:7.92`, and CSS `r` is a length — a bare number is one only in a browser being generous. Chromium accepts it; Safari drops the declaration, `r` computes to its initial `0`, and every pin vanishes while the land still draws. It reads as an empty map rather than as a broken rule, which is exactly why it survived being looked at in the wrong browser. The property carries its unit now, and the test fails if it stops.

## Not in this PR

**The 12 unticked items**, still open on [the issue comment](https://github.com/nstarman/nstarman.github.io/issues/22#issuecomment-5419646553). Eleven are in-person-or-online questions only you can answer, plus `york-seminar-talk`, where York University in Toronto and the University of York in England are both plausible and 5,600 km apart. `asa-astrostatistics-interest-group-paper-competition-talk` was left unticked too, so JSM 2024 / Portland is not applied. All twelve show under the map as not placed.

**Wiring `geocode-places.mjs --check` into CI.** It would catch a new talk whose location was never resolved, but the script is a by-hand tool by design and the map already reports an unplaced talk rather than hiding it, so a missing coordinate is visible without a failing build. `AGENTS.md` documents the format and the two commands instead.

**Three things noticed while checking**, none of them location work:

- `the-future-of-astrophysical-data` has `"Infrastructure & NYC, USA"` sitting in `details` — the title *The Future of Astrophysical Data Infrastructure* got truncated and its tail plus the location landed there. `comscicon-gta-2021` reads `"& Online Role: …"` the same way. Both now duplicate what `location` says.
- `iaus-43-talk` is IAU Symposium **403**, not 43.
- Eight titles now restate their own location — `EAS 26-S10 (Lausanne)`, `CWRU Seminar (Cleveland)`, `TevPA (Valencia)`, `DARK seminar (Copenhagen)`, `Texas A&M Seminar (Texas)`, `CCA Software seminar (NYC)`, `Princeton Thunch Seminar (Princeton)`, `Marche III … (Jesi)` — which reads as a stutter now that the place has its own column.
