### PR TITLE
Resync the collaborators from ORCID

### DIFF
--- a/config/collaborators.json
+++ b/config/collaborators.json
@@ -103,10 +103,20 @@
           "city": "New York",
           "region": "New York",
           "country": "US",
+          "role": "Research Scientist",
+          "kind": "employment",
+          "start": "2025-10",
+          "end": null
+        },
+        {
+          "organization": "Simons Foundation",
+          "city": "New York",
+          "region": "New York",
+          "country": "US",
           "role": "Associate Research Scientist",
           "kind": "employment",
           "start": "2021-08",
-          "end": null
+          "end": "2025-10"
         },
         {
           "organization": "Simons Foundation",
@@ -1305,6 +1315,26 @@
       "name": "Lina Necib",
       "affiliations": [
         {
+          "organization": "Massachusetts Institute of Technology",
+          "city": "Cambridge",
+          "region": "Massachusetts",
+          "country": "US",
+          "role": "Associate Professor",
+          "kind": "employment",
+          "start": "2026-07",
+          "end": null
+        },
+        {
+          "organization": "Massachusetts Institute of Technology",
+          "city": "Cambridge",
+          "region": "Massachusetts",
+          "country": "US",
+          "role": "Assistant Professor",
+          "kind": "employment",
+          "start": "2021-07",
+          "end": "2026-06"
+        },
+        {
           "organization": "Observatories of the Carnegie Institution of Washington",
           "city": "Pasadena",
           "region": "CA",
@@ -1312,7 +1342,7 @@
           "role": null,
           "kind": "employment",
           "start": "2020-10",
-          "end": null
+          "end": "2021-08"
         },
         {
           "organization": "California Institute of Technology",
@@ -1322,7 +1352,7 @@
           "role": "Postdoctoral Fellow",
           "kind": "employment",
           "start": "2017-09",
-          "end": null
+          "end": "2020-06"
         },
         {
           "organization": "Massachusetts Institute of Technology",

--- a/tests/collaborators.test.js
+++ b/tests/collaborators.test.js
@@ -70,12 +70,17 @@ describe('the collaborator database', () => {
   });
 
   it('keeps distinct posts at one employer distinct', () => {
-    // Normalising the place must not collapse a career into one row: two
-    // Simons Foundation posts share an address and differ in role and dates.
+    // Normalising the place must not collapse a career into one row: the Simons
+    // Foundation posts share an address and differ in role and dates.
+    //
+    // Counted rather than fixed at a number. This file is regenerated from
+    // ORCID, so a hard-coded two became wrong the day Price-Whelan was promoted
+    // — and a test that fails on someone else's promotion is testing the world,
+    // not the normaliser. The property is that the rows stay separate.
     const apw = doc.people.find((p) => p.orcid === '0000-0003-0872-7098');
     const simons = apw.affiliations.filter((a) => a.organization === 'Simons Foundation');
-    expect(simons.length).toBe(2);
-    expect(new Set(simons.map((a) => a.role)).size).toBe(2);
+    expect(simons.length).toBeGreaterThan(1);
+    expect(new Set(simons.map((a) => a.role)).size).toBe(simons.length);
   });
 
   it('sorts each history newest first', () => {


### PR DESCRIPTION
Lina updated her ORCID record. This is `node scripts/collect-collaborators.mjs` rerun and the result committed — the file says not to edit it by hand, so nothing here was.

Two people changed.

```
Lina Necib          + MIT, Assistant Professor   2021-07 – 2026-06
                    + MIT, Associate Professor   2026-07 –
                      Carnegie  2020-10 – 2021-08   (was open-ended)
                      Caltech   2017-09 – 2020-06   (was open-ended)

Adrian Price-Whelan + Simons Foundation, Research Scientist  2025-10 –
                      Associate Research Scientist  2021-08 – 2025-10  (was open-ended)
```

## The end dates are the part that matters

The map attaches a paper to whichever post was current when it appeared. Both of Lina's earlier posts had no end date, so every paper we have written together matched **both at once** and pinned to Pasadena:

| paper | before | after |
|---|---|---|
| Physics-Informed Neural Networks (2025-12) | Carnegie *and* Caltech | MIT |
| Galactic Amnesia (2026-05) | Carnegie *and* Caltech | MIT |
| Euclid Q1: geometry of dark matter halos (2026-06) | Carnegie *and* Caltech | MIT |
| Physics-Informed Neural Networks (2026-06) | Carnegie *and* Caltech | MIT |

Four papers from 2025 and 2026 were drawn in California, where she has not worked since 2021. They are in Cambridge now, and her trajectory runs Pasadena → Cambridge rather than stopping in Pasadena.

This is worth noticing beyond this one record: an open-ended post silently absorbs every later paper. It is not a bug in the map — "no end date" honestly means "still there" — but it means a stale ORCID record does not merely omit a pin, it actively puts papers in the wrong city.

## The test change

`keeps distinct posts at one employer distinct` asserted Price-Whelan had exactly two Simons Foundation posts with two distinct roles. He has three now, so it failed.

The count was the wrong thing to assert. This file is regenerated from a third party's ORCID record, so a hard-coded `2` became wrong the day he was promoted — and a test that fails on someone else's promotion is testing the world, not the normaliser. It now asserts the property the normaliser is responsible for: however many posts there are at one employer, they stay separate rows with distinct roles rather than being collapsed into one.

## Verification

`npm test` — 167 unit tests, schema, BibTeX, build, a11y and links all pass.

`node scripts/geocode-places.mjs --check` — all 114 places still resolved; no new institution appeared, so `config/places.json` is untouched.

Checked on the page: Lina now draws four dated pins with the two MIT posts separated by the co-location rosette, and the four papers listed under the 2021–2026 MIT post. No paper was stranded or newly placed anywhere in the database by this refresh — placed/unplaced totals are 55/7 before and after.
