### PR TITLE
Keep the GPA to the complete CV

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ from the `$schema` key.
   "title": "Stream Members Only: …",
   "summary": "One line. Always rendered, including in the 2-page CV.",
   "details": "Elaboration. Long CVs and website only — dropped from short presets.",
+  "detailsComplete": "Only the complete CV shows this. For a GPA.",
   "links": [ { "rel": "paper", "url": "https://…" } ],
   "refs":  ["trackstream"],           // other items, by bare id
   "tags":  ["streams", "machine-learning"],
@@ -83,14 +84,28 @@ from the `$schema` key.
 }
 ```
 
-### `summary` vs `details`
+### `summary` vs `details` vs `detailsComplete`
 
-This replaces the old LaTeX `% SKIP` preprocessor. `summary` always renders;
-`details` is dropped from the 1-page and 2-page CVs and kept in the np and
-complete CVs and on
-the website. Put the elaboration — thesis title, award citation, what the grant
-paid for — in `details`. Publications are the exception: their one-line is
-derived from `authors` and `venue`, so `summary` is usually omitted there.
+This replaces the old LaTeX `% SKIP` preprocessor. Three tiers, widest first:
+
+| field | where it renders |
+|---|---|
+| `summary` | everywhere, including the 1-page CV |
+| `details` | the website and the np and complete CVs; dropped by 1-page and 2-page |
+| `detailsComplete` | the complete CV alone |
+
+Put the elaboration — thesis title, award citation, what the grant paid for —
+in `details`. Publications are the exception: their one-line is derived from
+`authors` and `venue`, so `summary` is usually omitted there.
+
+`detailsComplete` is for a fact that is true and on the record but does not
+belong on a CV you hand someone — a GPA is the case it exists for. It is
+appended after `details`, the thesis and the supervisors, so a line index means
+the same thing whether or not it is included; the CV builder ticks lines by
+index, and inserting in the middle would silently move every tick after it.
+
+The complete CV is identified by `includeAll` in `config/presets.json`, not by
+its name, so nothing hard-codes which preset is the unabridged one.
 
 ### `type` and what each one adds
 

--- a/data/2014-cwru-bs.json
+++ b/data/2014-cwru-bs.json
@@ -18,7 +18,8 @@
   "supervisors": [
     "Stacy McGaugh"
   ],
-  "details": "Summa Cum Laude, GPA 4.0.",
+  "details": "Summa Cum Laude.",
+  "detailsComplete": "GPA 4.0.",
   "links": [
     {
       "rel": "homepage",

--- a/schema/item.schema.json
+++ b/schema/item.schema.json
@@ -84,6 +84,21 @@
         }
       ]
     },
+    "detailsComplete": {
+      "description": "Elaboration only the complete CV shows \u2014 the tier below `details`. `summary` always renders; `details` renders on the website and the long CVs and is dropped by the short presets; this renders in the complete CV alone. For the fact that is true and on the record but does not belong on a CV you hand someone, such as a GPA. Same string-or-lines shape as `details`, and appended after it.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        }
+      ]
+    },
     "links": {
       "type": "array",
       "items": {

--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -42,11 +42,15 @@ function posStops(section) {
 // point — a list of bare titles is not the CV you are about to compile.
 // `picked` is the starting selection, so the server renders the right ticks
 // rather than the client unticking 155 boxes after paint.
-const { cv, pick = false, picked = null, level = 'full' } = Astro.props;
+const { cv, pick = false, picked = null, level = 'full', completeLines = cv.includeAll } = Astro.props;
 const isPicked = (id) => !picked || picked.has(id);
 // Elaboration is a list of lines, and in the builder each one is its own
 // choice — inclusion is a tick, not a level.
-const detail = (i) => (cv.detail === 'full' || pick ? detailLines(i) : []);
+const detail = (i) => (cv.detail === 'full' || pick ? detailLines(i, { complete: cv.includeAll }) : []);
+// Which of those lines only the complete CV shows. They are appended last, so
+// everything from this index on is complete-only — the builder needs to know,
+// because seeding from NP must not tick a line the NP CV does not print.
+const baseLines = (i) => detailLines(i).length;
 const href = (n) => (n === 'np' ? '/cv/' : `/cv/${n}/`);
 
 // Every preset that renders this section, so the toggle offers exactly the
@@ -247,7 +251,8 @@ const money = (a) => {
               <span class="sub">
                 {pick && (
                   <input type="checkbox" class="subbox" data-id={item.id} data-line={i}
-                         checked={level === 'full'}
+                         data-complete={i >= baseLines(item) ? '' : undefined}
+                         checked={level === 'full' && (i < baseLines(item) || completeLines)}
                          aria-label={`Include this line under ${item.title}`} />
                 )}
                 {line.map((x) => (x.url ? <a href={x.url}>{x.t}</a> : x.t))}

--- a/src/lib/cvmodel.js
+++ b/src/lib/cvmodel.js
@@ -151,7 +151,7 @@ export function cvModel(presetName, only, keepLine) {
         // summary/details split, and what make_short.py could not express.
         // Span arrays, not strings: `details` may be several lines and may carry
         // inline links, and Typst would print the markup verbatim otherwise.
-        lines: detailLines(item).filter((_, i) =>
+        lines: detailLines(item, { complete: cv.includeAll }).filter((_, i) =>
           keepLine ? keepLine(item.id, i) : s.detail === 'full'),
         trailing: trailing(item),
         recipient: item.recipient ?? null,

--- a/src/lib/inline.js
+++ b/src/lib/inline.js
@@ -51,11 +51,21 @@ export function lines(long, base = '') {
  * must use. Shared so the page and the PDF cannot disagree about what an
  * entry's lines are — or, once the builder can tick them individually, about
  * which line index a tick refers to.
+ *
+ * `complete` adds the lines only the complete CV shows. It is off by default so
+ * every caller that has not thought about it gets the discreet answer: a field
+ * whose whole purpose is to appear in one place should not leak into a fourth
+ * renderer by being forgotten about.
+ *
+ * The extra lines go last, after the thesis and supervisors, so a line index
+ * means the same thing whether or not they are included — the builder ticks
+ * lines by index, and inserting in the middle would silently move its ticks.
  */
-export function detailLines(item) {
+export function detailLines(item, { complete = false } = {}) {
   return [
     ...lines(item.details),
     ...(item.thesis ? [spans(`Thesis: ${item.thesis}`)] : []),
     ...(item.supervisors?.length ? [spans(`Supervisors: ${item.supervisors.join(', ')}`)] : []),
+    ...(complete ? lines(item.detailsComplete) : []),
   ];
 }

--- a/src/lib/presets.js
+++ b/src/lib/presets.js
@@ -102,6 +102,11 @@ export function resolve(name, only) {
     name,
     label: spec.label,
     detail: spec.detail,
+    // The CV that takes every item is also the one that says every line, so it
+    // is what `detailsComplete` keys off. Read from the spec rather than by
+    // comparing the name to "complete", so a renderer never hard-codes which
+    // preset is the unabridged one.
+    includeAll: Boolean(spec.includeAll),
     sections: sections.filter((s) => s.items.length > 0 || s.entries?.length > 0),
   };
 }

--- a/src/pages/cv/builder.astro
+++ b/src/pages/cv/builder.astro
@@ -14,6 +14,10 @@ const cv = resolve('complete');
 const START = 'np';
 const picked = new Set(memberIds(START));
 const startLevel = preset(START).detail;
+// The complete CV is the only one that prints `detailsComplete`, so seeding the
+// picker from any other preset must leave those lines unticked — otherwise
+// "start from NP, compile" quietly puts back a line the NP CV does not have.
+const startsComplete = Boolean(preset(START).includeAll);
 const membership = Object.fromEntries(presetNames.map((n) => [n, memberIds(n)]));
 const total = cv.sections.reduce((n, s) => n + s.items.length, 0);
 // Stamped into a saved selection so it can be taken back to the data it names.
@@ -60,7 +64,7 @@ const site = buildInfo();
         <iframe id="preview" title="CV preview" hidden></iframe>
 
         <div id="tree">
-          <CvView cv={cv} pick picked={picked} level={startLevel} />
+          <CvView cv={cv} pick picked={picked} level={startLevel} completeLines={startsComplete} />
         </div>
       </div>
     </section>
@@ -72,6 +76,8 @@ const site = buildInfo();
   <script type="application/json" id="membership" set:html={JSON.stringify(membership)}></script>
   <script type="application/json" id="detaillevels"
           set:html={JSON.stringify(Object.fromEntries(presetNames.map((n) => [n, preset(n).detail])))}></script>
+  <script type="application/json" id="unabridged"
+          set:html={JSON.stringify(Object.fromEntries(presetNames.map((n) => [n, Boolean(preset(n).includeAll)])))}></script>
   <script type="application/json" id="siteinfo" set:html={JSON.stringify(site)}></script>
 
   <script>
@@ -89,6 +95,8 @@ const site = buildInfo();
     const boxes = () => [...document.querySelectorAll('.itembox')];
     const subs = () => [...document.querySelectorAll('.subbox')];
     const DETAIL = JSON.parse(document.getElementById('detaillevels').textContent);
+    // Which presets print the complete-only lines. Only the complete CV does.
+    const UNABRIDGED = JSON.parse(document.getElementById('unabridged').textContent);
     const SITE = JSON.parse(document.getElementById('siteinfo').textContent);
 
     /** An unticked line greys out in place, so the page keeps showing what it
@@ -203,7 +211,12 @@ const site = buildInfo();
         // A preset is not only which entries appear but how much each says, so
         // the detail controls move with it.
         const full = (DETAIL[t.dataset.preset] ?? 'full') === 'full';
-        subs().forEach((b) => (b.checked = full));
+        // A complete-only line belongs to the complete CV alone, so it stays
+        // unticked for every other preset even though they are "full" detail.
+        const unabridged = UNABRIDGED[t.dataset.preset] ?? false;
+        subs().forEach((b) => {
+          b.checked = full && (b.dataset.complete === undefined || unabridged);
+        });
         applyDetail();
         recount();
         status(`Selection set from ${t.textContent}.`);

--- a/tests/cvmodel.test.js
+++ b/tests/cvmodel.test.js
@@ -42,6 +42,32 @@ describe('detail levels', () => {
     const onlyFirst = cvModel('complete', undefined, (_id, line) => line === 0);
     for (const i of all(onlyFirst)) expect(i.lines.length).toBeLessThanOrEqual(1);
   });
+
+  it('prints `detailsComplete` in the complete CV and nowhere else', () => {
+    // The GPA is on the record and belongs in the unabridged CV; it is not
+    // something to hand a search committee. `details` is the wrong tier for it
+    // because np and the website both print that.
+    const text = (model, id) => {
+      const item = all(model).find((i) => i.id === id);
+      return (item?.lines ?? []).flat().map((sp) => sp.t).join(' ');
+    };
+    const record = itemById('cwru-bs');
+    expect(record.detailsComplete).toBe('GPA 4.0.');
+
+    expect(text(cvModel('complete'), 'cwru-bs')).toContain('GPA 4.0.');
+    for (const name of ['np', '2page', '1page']) {
+      expect(text(cvModel(name), 'cwru-bs')).not.toContain('GPA');
+    }
+    // And the tier above it still prints everywhere it did before.
+    expect(text(cvModel('np'), 'cwru-bs')).toContain('Summa Cum Laude.');
+  });
+
+  it('appends a complete-only line last, so line indices do not shift', () => {
+    // The builder ticks lines by index. If the extra line were inserted among
+    // the others, every tick after it would silently point at a different line.
+    const lines = all(cvModel('complete')).find((i) => i.id === 'cwru-bs').lines;
+    expect(lines.at(-1).map((sp) => sp.t).join(' ')).toContain('GPA 4.0.');
+  });
 });
 
 describe('publications', () => {


### PR DESCRIPTION
"GPA 4.0." now appears in the complete CV and nowhere else.

## Why it needed a new field

The record read `"details": "Summa Cum Laude, GPA 4.0."`, and `details` renders on the website and in the np CV as well as the complete one. One string, three audiences.

`summary` and `details` had no tier below them, so this adds one:

| field | where it renders |
|---|---|
| `summary` | everywhere, 1-page included |
| `details` | the website and the np and complete CVs; dropped by 1-page and 2-page |
| `detailsComplete` | the complete CV alone |

`detailsComplete` is for a fact that is true and on the record but does not belong on a CV you hand someone. A GPA is the case it exists for.

The 1-page and 2-page CVs already dropped `details` wholesale, so they never showed the GPA — the two places that did were **Background** and the **np** CV.

## Where it lands now

Verified against the built site and `pdftotext` on the compiled PDFs, not from the source:

| | Summa Cum Laude | GPA 4.0. |
|---|---|---|
| Home page, Background | yes | **no** |
| Complete CV | yes | **yes** |
| NP CV | yes | **no** |
| 2-page CV | — (drops `details`) | no |
| 1-page CV | — (drops `details`) | no |

In the complete CV the lines read:

```
Summa Cum Laude.
Supervisors: Stacy McGaugh
GPA 4.0.
```

## The builder was the trap

`/cv/builder` compiles from the complete CV with a checkbox per line, and its preset buttons only knew `detail: full` against `detail: summary`. Clicking **NP** ticked *every* line — so "start from NP, compile" would have handed back a CV with the GPA in it, which is the exact thing this PR removes.

Complete-only lines now carry a marker and stay unticked for every preset except the unabridged one. Checked in the browser:

| action | Summa Cum Laude | Supervisors | GPA 4.0. |
|---|---|---|---|
| initial load (seeded from NP) | ticked | ticked | **unticked** |
| click Complete | ticked | ticked | **ticked** |
| click NP | ticked | ticked | **unticked** |
| click 1P | unticked | unticked | unticked |

The line is still *offered* in the builder — it is your CV to assemble — it just is not on by default unless you asked for the complete one.

## Two details worth knowing

**Appended last, deliberately.** The extra lines go after `details`, the thesis and the supervisors. The builder ticks lines by index and saves those indices into a selection file, so inserting in the middle would silently move every tick after it. There is a test for this.

**`includeAll`, not the name.** Nothing compares a preset name to `"complete"`. `resolve()` now exposes the spec's `includeAll`, which is what makes complete complete, so renaming a preset or adding another unabridged one does not need a renderer change.

## Verification

`npm test` — 169 unit tests (2 new), schema, BibTeX, build, a11y and links all pass. `npm run build:pdf` still gives one page for the 1-page CV and two for the 2-page one.

The new tests assert the requirement directly: `detailsComplete` prints in `complete` and in none of `np`, `2page`, `1page`; `details` still prints where it always did; and the complete-only line is last.

One gap to name: the home page renders correctly in the DOM and in the built HTML, both checked, but the browser screenshots came back blank — a dev-server dep-optimization hiccup (`504 Outdated Optimize Dep`), not something in this change. The built `dist/index.html` contains "Summa Cum Laude." and no "GPA", which is the artifact that actually ships.
