### PR TITLE
Mark the section you jumped to, not the one before it

### DIFF
--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -338,5 +338,21 @@ const money = (a) => {
     update();
     addEventListener('scroll', update, { passive: true });
     addEventListener('resize', update, { passive: true });
+
+    // A fragment jump moves the page, and cannot be relied on to deliver a
+    // `scroll` event for it — so on its own, `scroll` leaves the rail marking
+    // wherever the reader was standing before they clicked. That is the half of
+    // this bug that survived the first fix: the landing position was then right
+    // and the mark was never recomputed to notice.
+    //
+    // Three signals, because each covers a gap in the others: `hashchange` for
+    // a click on the rail or any in-page anchor, `scrollend` for a smooth
+    // scroll that has come to rest (not everywhere yet, hence the guard), and a
+    // click on the rail itself for the case where the hash is unchanged because
+    // the reader clicked the section they were already in.
+    const soon = () => requestAnimationFrame(() => requestAnimationFrame(update));
+    addEventListener('hashchange', soon);
+    if ('onscrollend' in window) addEventListener('scrollend', update);
+    document.querySelector('.cvtoc')?.addEventListener('click', soon);
   }
 </script>

--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -269,6 +269,7 @@ const money = (a) => {
 })}
 
 <script>
+  import { currentSection } from '../lib/scrollspy.js';
   // Switching detail level should not throw you to the top of the section.
   // The href carries the anchor so it still works without JavaScript; with it,
   // we remember where the heading sat in the viewport and put it back there on
@@ -323,17 +324,16 @@ const money = (a) => {
       for (const [key, a] of links) a.classList.toggle('is-current', key === id);
     };
 
-    // Track the heading nearest the top of the viewport rather than whichever
-    // happens to be intersecting: sections here vary from one row to thirty-five,
-    // so "is visible" is true of several at once.
+    // Which heading is current is decided in lib/scrollspy.js, against numbers
+    // rather than elements, so the comparison that used to mark the wrong
+    // section can be tested without a browser.
     const update = () => {
       // No bottom-out special case: .cvsec--last is tall enough for the final
       // heading to reach the top like any other, so the same rule decides it.
-      let best = heads[0];
-      for (const h of heads) {
-        if (h.getBoundingClientRect().top - topGap <= 0) best = h;
-      }
-      mark(best.id);
+      mark(currentSection(
+        heads.map((h) => ({ id: h.id, top: h.getBoundingClientRect().top })),
+        topGap,
+      ));
     };
     update();
     addEventListener('scroll', update, { passive: true });

--- a/src/lib/scrollspy.js
+++ b/src/lib/scrollspy.js
@@ -1,0 +1,41 @@
+// Which section heading the reader is currently in.
+//
+// Split out of the CV page's inline script so it can be tested with plain
+// numbers instead of a browser: the bug it exists to prevent was a comparison
+// against zero, and that is exactly the kind of thing a unit test pins down and
+// a manual look does not.
+
+/**
+ * How far below the gap line a heading may still count as reached, in CSS px.
+ *
+ * An anchor jump lands a heading exactly on its own `scroll-margin-top`, so in
+ * principle `top === topGap`. In practice the browser settles the scroll on a
+ * device pixel and the heading comes to rest a fraction *below* the line —
+ * measured at 0.06 to 0.24px across the CV's headings. A strict `<= 0` therefore
+ * missed the section the reader had just jumped to and marked the one before it,
+ * on nine of the fifteen links.
+ *
+ * One pixel: comfortably more than the rounding, and nothing beside it, since
+ * consecutive headings on this page are hundreds of pixels apart.
+ */
+export const REACHED_EPS = 1;
+
+/**
+ * @param {{id: string, top: number}[]} heads  headings in document order, `top`
+ *   as viewport coordinates
+ * @param {number} topGap  the offset headings are scrolled to
+ * @returns {string|null} the id to mark current
+ *
+ * The last heading that has reached the line, rather than whichever is
+ * intersecting: sections here run from one row to thirty-five, so "is visible"
+ * is true of several at once. Above the first heading, the first one is current
+ * — the reader is at the top of the document, not in nothing.
+ */
+export function currentSection(heads, topGap) {
+  if (!heads.length) return null;
+  let best = heads[0];
+  for (const h of heads) {
+    if (h.top - topGap <= REACHED_EPS) best = h;
+  }
+  return best.id;
+}

--- a/tests/scrollspy.test.js
+++ b/tests/scrollspy.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { currentSection, REACHED_EPS } from '../src/lib/scrollspy.js';
+
+// The offset headings are scrolled to, as the CV page computes it: 6.6rem.
+const GAP = 105.6;
+
+describe('the CV contents rail', () => {
+  it('marks the section you jumped to, not the one before it', () => {
+    // The bug, with the numbers measured off the page. Clicking a contents link
+    // settles the heading a fraction *below* its own scroll-margin-top, because
+    // the browser lands the scroll on a device pixel. Comparing `<= 0` therefore
+    // decided the heading had not been reached and marked its predecessor —
+    // on nine of the fifteen links, "Select Publications" among them.
+    const landed = [
+      { id: 'education', top: -511.14 },
+      { id: 'positions', top: -257.66 },
+      { id: 'publications', top: GAP + 0.19 },   // the one just jumped to
+      { id: 'awards-major', top: 1871.66 },
+    ];
+    expect(currentSection(landed, GAP)).toBe('publications');
+  });
+
+  it('marks each of the measured landings correctly', () => {
+    // Every delta seen on the page, so a smaller tolerance cannot pass this.
+    for (const delta of [0.06, 0.07, 0.13, 0.19, 0.2, 0.24]) {
+      const heads = [
+        { id: 'before', top: -300 },
+        { id: 'target', top: GAP + delta },
+        { id: 'after', top: GAP + 900 },
+      ];
+      expect(currentSection(heads, GAP)).toBe('target');
+    }
+  });
+
+  it('does not reach forward to a heading that is genuinely below', () => {
+    // The tolerance must not become "near enough": a heading a screen down is
+    // not the section being read.
+    const heads = [
+      { id: 'current', top: -40 },
+      { id: 'next', top: GAP + 200 },
+    ];
+    expect(currentSection(heads, GAP)).toBe('current');
+    // And not one just past the tolerance either.
+    expect(currentSection(
+      [{ id: 'current', top: -40 }, { id: 'next', top: GAP + REACHED_EPS + 0.5 }],
+      GAP,
+    )).toBe('current');
+  });
+
+  it('marks the last heading that has passed, not the first', () => {
+    const heads = [
+      { id: 'a', top: -900 },
+      { id: 'b', top: -400 },
+      { id: 'c', top: -20 },
+      { id: 'd', top: 800 },
+    ];
+    expect(currentSection(heads, GAP)).toBe('c');
+  });
+
+  it('marks the first heading while still above it', () => {
+    // At the top of the document the reader is in the first section, not in none.
+    expect(currentSection([{ id: 'a', top: 400 }, { id: 'b', top: 900 }], GAP)).toBe('a');
+  });
+
+  it('has nothing to say about an empty page', () => {
+    expect(currentSection([], GAP)).toBe(null);
+  });
+});


### PR DESCRIPTION
Clicking a contents link on the CV scrolled to the right place and then highlighted the wrong section. Reported for **Select Publications**, which said *Professional Appointments*, and again for **Select Fellowships & Awards**, which said *Select Publications*.

Two causes, one behind the other.

## 1. The mark was never recomputed after a jump

This is the one that produced the reported behaviour, and the larger half.

The rail listened for `scroll` and `resize`. A fragment jump moves the viewport but cannot be relied on to deliver a `scroll` event for it, so clicking a contents link moved the page and **left the mark exactly where it was** — on whichever section the reader had been standing in before they clicked. That matches both screenshots: the mark is not "off by one", it is stale.

Three signals now, each covering a gap in the others:

- `hashchange` — a click on the rail, or any in-page anchor
- `scrollend` — a smooth scroll come to rest, guarded because it is not everywhere yet
- a click on the rail itself — for when the hash does not change, because the reader clicked the section they were already in

## 2. The landing position failed its own test

Underneath that, the comparison was also wrong, and would have shown up as a genuine off-by-one once the mark was being recomputed at all.

An anchor jump lands a heading exactly on its own `scroll-margin-top`, so in principle `top === topGap`. In practice the browser settles the scroll on a device pixel and the heading comes to rest a fraction **below** the line. Measured on the page:

```
positions          +0.24px      publications       +0.19px
awards-major       +0.06px      grants-major       +0.13px
software           +0.07px      talks-contributed  +0.20px
```

`top - topGap <= 0` therefore concluded the heading had not been reached and picked its predecessor. A one-pixel tolerance settles it — far more than the rounding, far less than the hundreds of pixels between consecutive headings, so it cannot reach forward to a section that is genuinely below.

That comparison moves out of the page's inline script into `src/lib/scrollspy.js` and takes numbers instead of elements, so the arithmetic is testable without a DOM.

## Verification

Six unit tests covering the comparison, including every landing delta measured off the page. Two fail against the old `<= 0` — checked by reverting the constant and watching them go red.

The behavioural half cannot be unit-tested without a DOM, so it was checked in a browser **against the built site**, not the dev server:

| | before | after |
|---|---|---|
| contents links marking the wrong section | 14 of 15 | **0 of 15** |

Plus the two reported cases specifically (click Fellowships & Awards, click Publications), a click followed by further manual scrolling, and plain scrolling at five positions from the top of the page to the bottom — each checked against an independently computed expectation.

`npm test` — 173 unit tests, schema, BibTeX, build, a11y and links all pass.

## A note on how the first attempt got this wrong

The first commit claimed all fifteen links were fixed. That verification was invalid twice over, and both are worth recording because they are easy to repeat:

- The check dispatched a synthetic `scroll` event before reading the mark. That is precisely the signal the page was missing, so the test supplied the bug's own cure and then reported success.
- Later measurements ran against a dev server that was serving stale HTML — its HMR socket had dropped, and the page under test did not contain the edits at all. `curl | grep` on the served markup showed the new handler absent from the dev server and present in the build.

Everything above was re-measured against `npm run build` output after that was found.
