### PR TITLE
Credit all three unxt authors, not just one

### DIFF
--- a/data/2025-03-unxt-joss.json
+++ b/data/2025-03-unxt-joss.json
@@ -19,6 +19,18 @@
       "given": "Nathaniel",
       "me": true,
       "orcid": "0000-0003-3954-3291"
+    },
+    {
+      "family": "Price-Whelan",
+      "given": "Adrian M.",
+      "orcid": "0000-0003-0872-7098",
+      "affiliation": "Center for Computational Astrophysics, Flatiron Institute, USA"
+    },
+    {
+      "family": "Nibauer",
+      "given": "Jake",
+      "orcid": "0000-0001-8042-5794",
+      "affiliation": "Department of Physics, Princeton University, USA"
     }
   ],
   "venue": {
@@ -50,7 +62,6 @@
     "units",
     "open-source"
   ],
-  "internal": "Co-author list still to import from JOSS.",
   "citekey": "Starkman+:2025:unxt",
   "abstract": "unxt is a Python package for unit-aware computing with JAX. unxt is built on top of quax, which provides a framework for building array-like objects that can be used with JAX. unxt extends quax to provide support for unit-aware computing using the astropy.units package as a units backend. unxt provides seamless integration of physical units into high performance numerical computations, significantly enhancing the capabilities of JAX for scientific applications."
 }


### PR DESCRIPTION
The JOSS entry for `unxt` listed me alone and carried a note — *"Co-author list still to import from JOSS"* — that never got acted on. Imported from the Crossref record for [10.21105/joss.07771](https://doi.org/10.21105/joss.07771):

1. Nathaniel Starkman
2. Adrian M. Price-Whelan — `0000-0003-0872-7098`
3. Jake Nibauer — `0000-0001-8042-5794`

Affiliations filled by `scripts/fetch-affiliations.mjs` from the same record, so they say where each author was for *this* paper (Flatiron CCA; Princeton Physics) rather than where they are now. Citekey `Starkman+:2025:unxt` was already right for three or more authors. Stale `internal` note dropped.

`npm run validate`, `test:unit`, `test:bibtex` and `collect-collaborators.mjs --check` all pass — both ORCIDs were already in `config/collaborators.json`, so the collaborator DB is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)