### PR TITLE
Read the collaborator picker as an index, not a guest list

### DIFF
--- a/src/components/CollabMini.astro
+++ b/src/components/CollabMini.astro
@@ -10,7 +10,7 @@
 // of thirty-four people answer a question rather than just decorate. Here it
 // earns more than it does on /research/: the CV it sits beside is a list of
 // papers, so picking a collaborator can light up the ones we wrote together.
-import { collaboratorMap, map } from '../lib/collabmap.js';
+import { collaboratorMap, lastFirst, map } from '../lib/collabmap.js';
 
 const people = collaboratorMap();
 
@@ -35,8 +35,12 @@ const entries = people.map((person, c) => {
     ...person.pins.flatMap((p) => p.papers.map((q) => q.id)),
     ...person.unplacedPapers.map((q) => q.id),
   ])];
-  return { c, name: person.name, places: [...at.values()], papers };
+  return { c, name: lastFirst(person.name), places: [...at.values()], papers };
 });
+
+// Surname first, so the picker reads like an index rather than a list of
+// first names — the same order the CV's own references are scanned in.
+entries.sort((a, b) => a.name.localeCompare(b.name));
 
 // Shared places last, so they are drawn over the plain ones rather than under.
 const dots = entries

--- a/src/lib/collabmap.js
+++ b/src/lib/collabmap.js
@@ -41,6 +41,21 @@ function papersByAuthor() {
   return out;
 }
 
+// Nobiliary particles travel with the surname: "van Kerkwijk", not "Kerkwijk".
+const PARTICLES = new Set(['van', 'von', 'de', 'der', 'den', 'del', 'della', 'di', 'da', 'dos', 'la', 'le']);
+
+/** "Marten H. van Kerkwijk" -> "van Kerkwijk, Marten H." — index order, for
+ *  lists a reader scans by surname. Anything without a given name is left be. */
+export function lastFirst(name) {
+  const parts = name.split(' ');
+  // ponytail: a two-word name always splits, so a particle surname on its own
+  // ("Le Guin") comes out wrong. No collaborator has one; widen if one arrives.
+  let i = parts.length - 1;
+  while (i > 1 && PARTICLES.has(parts[i - 1].toLowerCase())) i -= 1;
+  const given = parts.slice(0, i).join(' ');
+  return given ? `${parts.slice(i).join(' ')}, ${given}` : name;
+}
+
 /** Did a post that ran `start`..`end` cover this date? */
 const covers = (post, date) =>
   Boolean(post.start) && post.start <= date && (!post.end || post.end >= date);

--- a/tests/collabmap.test.js
+++ b/tests/collabmap.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { collaboratorMap, project, toXY, map, MAX_PIN_DRIFT, KM_PER_UNIT, MAX_DRIFT_MILES }
+import { collaboratorMap, lastFirst, project, toXY, map, MAX_PIN_DRIFT, KM_PER_UNIT, MAX_DRIFT_MILES }
   from '../src/lib/collabmap.js';
 
 const people = collaboratorMap();
@@ -182,5 +182,15 @@ describe('the collaborator map', () => {
     const unplaced = people.reduce((n, p) => n + p.unplacedPapers.length, 0);
     expect(placed).toBeGreaterThan(0);
     expect(placed + unplaced).toBeGreaterThan(placed);
+  });
+});
+
+describe('surname-first names', () => {
+  it('moves the given names behind the surname, particles included', () => {
+    expect(lastFirst('Adrian M. Price-Whelan')).toBe('Price-Whelan, Adrian M.');
+    expect(lastFirst('Marten H. van Kerkwijk')).toBe('van Kerkwijk, Marten H.');
+    expect(lastFirst('C. E. Brasseur')).toBe('Brasseur, C. E.');
+    // A mononym has nothing to move.
+    expect(lastFirst('Cher')).toBe('Cher');
   });
 });


### PR DESCRIPTION
The CV minimap's picker lists thirty-nine collaborators. Sorted by first name, finding someone means reading every entry; sorted by surname it matches the order of the reference list sitting next to it.

- `lastFirst` in `src/lib/collabmap.js` — last word is the surname, with any nobiliary particle carried along so "van Kerkwijk" stays whole.
- `CollabMini.astro` formats and sorts the picker with it.
- The full map on `/research/` is untouched: its labels sit beside points on a map, not in a list to be scanned.

Rendered order: `Bovy, Jo | Brasseur, C. E. | Calvetti, Daniela | … | van Kerkwijk, Marten H.`

A two-word name whose surname *is* a particle ("Le Guin") mis-splits. No collaborator has one; noted with a `ponytail:` comment where the guard lives.

Tests: 181 passing, including a new case for the split. `astro build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)