### PR TITLE
The minimap belongs on the CV builder too

### DIFF
--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -96,7 +96,7 @@ const money = (a) => {
   const Head = collapsed ? 'summary' : 'div';
   const selectable = pick && s.items.length > 0;
   return (
-  <Wrap class={`cvsec${i === 0 ? ' cvsec--first' : ''}${i === cv.sections.length - 1 ? ' cvsec--last' : ''}${selectable ? ' pickgroup' : ''}${!pick && s.id === 'publications' ? ' cvsec--hasmap' : ''}`}>
+  <Wrap class={`cvsec${i === 0 ? ' cvsec--first' : ''}${i === cv.sections.length - 1 ? ' cvsec--last' : ''}${selectable ? ' pickgroup' : ''}${s.id === 'publications' ? ' cvsec--hasmap' : ''}`}>
     <Head class="cvsechead">
       {selectable && (
         <input type="checkbox" class="groupbox"
@@ -149,7 +149,7 @@ const money = (a) => {
           link sits, so it reads as part of that column rather than as another
           control on the heading row. Publications only: the map is about the
           people in these bylines. */}
-      {!pick && s.id === 'publications' && (
+      {s.id === 'publications' && (
         <button type="button" class="cvminibtn" aria-expanded="false" aria-controls="cv-collab-map"
                 aria-label="Show where my collaborators have worked"
                 title="Show where my collaborators have worked">
@@ -276,7 +276,7 @@ const money = (a) => {
         right margin and sticks while the section is on screen, so the section's
         own box is what stops it: past the last publication it scrolls away with
         everything else rather than following the reader down the page. */}
-    {!pick && s.id === 'publications' && <CollabMini />}
+    {s.id === 'publications' && <CollabMini />}
   </Wrap>
   );
 })}


### PR DESCRIPTION
## Changing code or schema

**What and why:**

The collaborator minimap was rendered only when `CvView` was *not* in picker
mode, so `/cv/` had it and `/cv/builder/` — the same CV, the same publications,
the same right margin — did not.

Nothing about the picker made it unavailable. The `}` gutter the button is
centred on is drawn on the builder as well, the contents rail it shares its
78rem breakpoint with is already shown there, and the rows it marks are exactly
the rows the tick-boxes sit on. So the fix is the three `!pick &&` guards, gone:
the `cvsec--hasmap` class, the toggle button, and the `<CollabMini />` itself.

It earns more here than beside a finished CV: picking a collaborator lights up
the papers you wrote together *in the list you are choosing from*, so "the ones
with Adrian" is now something you can see while ticking rather than something
you have to remember.

Verified in the browser at 1400px on `/cv/builder/`: the map opens at x=1124,
25px clear of the source-mark column, no horizontal overflow; its sticky top
(106px) clears the builder's condensed compile bar (94px); picking a
collaborator narrows the map to 5 dots and marks 4 picker rows. Below 78rem it
hides there exactly as it does on the CV.

- [x] `npm run test:schema` passes
- [x] If a `link.rel` value or a `type` was added, every renderer was updated in this PR — n/a
- [x] If a constraint was added, `schema/invalid/` gained a fixture proving it is enforced — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)