### PR TITLE
Make a CV style a unit, and the gutter map three files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ config/          things that are configuration rather than items: the CV presets
                  the person, and the generated contributions list
 schema/          the item JSON Schema, plus invalid fixtures the tests assert on
 src/             the Astro site
-cv/              the Typst CV template, and the portrait and QR it draws
+cv/              the Typst CV template — cv.typ, lib/ (the palette and the
+                 styles), and the portrait and QR it draws
 tests/           vitest suites over src/lib and the generated data
 scripts/         test, build and generation scripts
 public/          served verbatim: CNAME, files/starkman_cv.pdf, and the fonts
@@ -56,10 +57,23 @@ why `npm test` builds in the middle rather than at the end.
 ## The CV
 
 The four pre-built PDFs and the in-browser builder at `/cv/builder/` compile the
-same `cv/cv.typ` from the same render model, so the PDF and the site cannot
+same template from the same render model, so the PDF and the site cannot
 disagree about what a preset contains. Under CI the Typst CLI reads `cv.json`
 off disk; in the browser typst.ts is handed the same filename through its
 virtual filesystem. Nothing forks.
+
+### The template, in three pieces
+
+| file | what is in it |
+|---|---|
+| [`cv/cv.typ`](cv/cv.typ) | the document — the header, the shape of a section, and the loop over `cv.json`. Names no colour, no font and no glyph. |
+| [`cv/lib/theme.typ`](cv/lib/theme.typ) | the palette, and the two figure styles that are not the document's old-style default |
+| [`cv/lib/styles.typ`](cv/lib/styles.typ) | the icon fonts, the mark table, and one unit per style |
+
+`cv/` is the compilation root in both runtimes, so `cv/lib/styles.typ` is
+`/lib/styles.typ` to typst.ts and the relative imports resolve unchanged either
+way. The builder globs `/cv/**/*.typ` into that virtual filesystem, so a new
+module needs no change there.
 
 ### Styles
 
@@ -82,11 +96,22 @@ the one- and two-page contracts cannot be affected by a style. (Both hold at
 one and two pages in either style regardless, which is worth knowing: words are
 wider than glyphs.)
 
-Adding a style is a branch in `cv.typ` behind that key plus an `<option>` in
-`src/pages/cv/builder.astro` — not a second template. Call sites that pair a
-mark with words go through one `marked()` helper, so the styles cannot drift
-apart; only a mark standing *alone* needs a deliberate fallback, or it compiles
-to an empty link.
+A style is a self-contained **unit** rather than a branch: one entry in `STYLES`
+in [`cv/lib/styles.typ`](cv/lib/styles.typ), answering three questions and
+nothing else.
+
+| the unit answers | asked by |
+|---|---|
+| `glyph(name)` | a mark drawn beside words — a section heading, a contact line. `none` draws nothing. |
+| `solo(name, word)` | a mark standing *alone*, given the word it was standing in for — a bare `arXiv` or `paper` link on a publication. Without a deliberate answer here a style compiles an empty link. |
+| `trail(links)` | a run of marks — the `code, docs, data` trail at the end of an entry. |
+
+`marked()`, a mark with words beside it, is derived from `glyph` rather than
+restated, so a style cannot answer those two inconsistently. Everything else is
+shared — the same type, the same spacing, the same sections, off the same
+model — which is why adding a style is that entry plus an `<option>` in
+`src/pages/cv/builder.astro`, touches `cv.typ` not at all, and never becomes a
+second template.
 
 ## Generated data
 

--- a/cv/cv.typ
+++ b/cv/cv.typ
@@ -14,7 +14,19 @@
 // rather than the words "code" and "docs". Set 11pt here rather than 12, which
 // keeps most of the reading gain without the page count.
 //
+// Three files, and this is the document:
+//
+//   cv/cv.typ          the header, the section shapes, and the body loop
+//   cv/lib/theme.typ   the palette, and the figures that are not old-style
+//   cv/lib/styles.typ  the marks, and one unit per style — see the README
+//
+// So nothing here names a colour, a font or a glyph, and adding a style never
+// touches this file.
+//
 //   typst compile --root . cv/cv.typ out.pdf
+
+#import "lib/theme.typ": ink, accent, faint, orcid, accentsoft, accentline, headerwash, tnum, lnum
+#import "lib/styles.typ": styled
 
 #let cv = json("cv.json")
 #let p = cv.person
@@ -24,25 +36,11 @@
 // the top and two-thirds empty at the bottom.
 #let tight = cv.preset == "1page"
 
-// Which pre-built style. "default" draws the marks; "plain" spells them out in
-// words instead, for anywhere a row of glyphs is unwelcome — a plain-text ATS,
-// a printer that renders symbol fonts badly, or simply a preference. Only the
-// browser builder sets it, so the CLI PDFs are always the default and their
-// page-count contracts are unaffected.
-#let plain = cv.at("style", default: "default") == "plain"
-
-#let ink = rgb("#111111")
-#let accent = rgb("#003399") // linkcolour: rgb(0, 0.2, 0.6)
-#let faint = rgb("#808080") // \grayhref: gray 0.5
-#let orcid = rgb("#A6CE39") // orcidlogocol
-// The publication status pill, same two tints the website uses.
-#let accentsoft = rgb("#EAF0F9")
-#let accentline = rgb("#7FA6D9")
-// The header sits on this. Barely there by intent — enough to read as one
-// block rather than four columns that happen to be adjacent, not enough to
-// look like a filled panel, and light enough to survive an office printer
-// without banding.
-#let headerwash = luma(250)
+// Which style. Each is a self-contained unit in lib/styles.typ answering how a
+// mark is drawn beside words (`marked`), standing alone (`solo`), and in a run
+// of them (`trail`). Only the browser builder sets the key, so the CLI PDFs are
+// always the default and their page-count contracts are unaffected.
+#let (glyph, solo, trail, marked) = styled(cv.at("style", default: "default"))
 
 #set document(title: p.name + " — " + cv.label, author: p.name)
 // geometry scale=0.9 on A4, hmarginratio 1:1, vmarginratio 2:3
@@ -66,82 +64,12 @@
   number-type: "old-style",
 )
 
-// Lining and tabular: equal-width, cap-height digits, for the places where
-// figures form a column and have to align down the page rather than read as
-// part of a sentence.
-#let tnum(body) = text(number-type: "lining", number-width: "tabular", body)
-
-// Lining but proportional, for identifiers rather than columns. An ORCID iD, an
-// arXiv number or a postcode is transcribed digit by digit rather than read as
-// a quantity, and old-style figures — which vary in height by design — make
-// that harder for no gain.
-#let lnum(body) = text(number-type: "lining", body)
 #set par(
   justify: true,
   spacing: 0pt,
   leading: if tight { 0.42em } else { 0.5em },
 )
 #show link: set text(fill: accent)
-
-// ── icons ─────────────────────────────────────────────────────────────────
-// The same fonts the LaTeX CV uses — Font Awesome 5 Free Solid, its Brands
-// companion, and Academicons — vendored in public/fonts/. Real glyphs rather
-// than traced SVGs: they hint and scale like type, and they take a fill, so one
-// definition serves every colour.
-#let FA = "Font Awesome 5 Free Solid"
-#let FAB = "Font Awesome 5 Brands"
-#let AI = "Academicons"
-
-// name -> (family, codepoint), keyed by the names presets.json and REL_ICON use
-#let MARKS = (
-  // link trails
-  ads: (AI, "\u{E9CB}"),
-  arxiv: (AI, "\u{E974}"),
-  zenodo: (FA, "\u{F1C0}"), // \faIcon{database}, as in the LaTeX header
-  paper: (FA, "\u{F15C}"), // file-alt
-  repo: (FA, "\u{F6E3}"), // hammer — the reproducible-paper mark
-  github: (FAB, "\u{F09B}"),
-  code: (FA, "\u{F121}"),
-  docs: (FA, "\u{F05A}"), // info-circle
-  data: (FA, "\u{F1C0}"), // database
-  slides: (FA, "\u{F15C}"),
-  link: (FA, "\u{F0C1}"),
-  email: (FA, "\u{F0E0}"), // envelope
-  globe: (FA, "\u{F0AC}"),
-  orcid: (FAB, "\u{F8D2}"),
-  // section marks
-  education: (FA, "\u{F19C}"), // university
-  positions: (FA, "\u{F6FF}"), // network-wired
-  publications: (FA, "\u{F15C}"), // file-alt
-  awards: (FA, "\u{F559}"), // award
-  grants: (FA, "\u{F0D6}"), // money-bill
-  talks: (FA, "\u{F51C}"), // chalkboard-teacher
-  conferences: (FA, "\u{F0C0}"), // users
-  mentoring: (FA, "\u{E068}"), // people-arrows
-  teaching: (FA, "\u{F5D1}"), // apple-alt
-  service: (FA, "\u{F2B5}"), // handshake
-  panels: (FA, "\u{F0E3}"), // gavel
-  outreach: (FA, "\u{F234}"), // user-plus
-  media: (FA, "\u{F1EA}"), // newspaper
-)
-
-#let icon(name, size: 1em, fill: accent) = {
-  let (family, glyph) = MARKS.at(name, default: MARKS.link)
-  text(font: family, size: size, fill: fill, glyph)
-}
-
-// A link whose whole body is a mark.
-#let iconlink(url, name, size: 1em, fill: accent) = link(
-  url,
-  icon(name, size: size, fill: fill),
-)
-
-// A mark with words beside it — or, in the plain style, the words on their own.
-// Every call site that pairs the two goes through this, so switching styles is
-// one branch rather than one per mark.
-#let marked(name, body, size: 1em, fill: accent) = if plain { body } else {
-  [#icon(name, size: size, fill: fill) #body]
-}
 
 // ── header ────────────────────────────────────────────────────────────────
 // Four columns across the full measure rather than five centred lines: a QR to
@@ -227,10 +155,13 @@
   // its own first entry, so they should not be equal: 9.2pt each way left a
   // heading sitting almost on the entry above it.
   v(if tight { 8pt } else { 15pt })
+  // `none` twice over: no mark named for this section, or a style that draws
+  // none. Both mean the heading is the words alone.
+  let g = if mark == none { none } else { glyph(mark, size: 0.95em, fill: ink) }
   block(breakable: false, sticky: true)[
     #set par(justify: false, spacing: 0pt)
     #text(size: 15.6pt)[
-      #if mark != none and not plain [#icon(mark, size: 0.95em, fill: ink) #h(2pt)]
+      #if g != none [#g #h(2pt)]
       #smallcaps(title)
     ]
     #v(4.5pt)
@@ -258,18 +189,6 @@
 #let linked(sp) = sp.map(s => if "url" in s and not s.url.starts-with("#") {
   link(s.url)[#s.t]
 } else { s.t }).join()
-
-// The resource trail: marks, not words, so it costs the end of a line instead
-// of a line of its own.
-#let trail(links, tint: accent, size: 1em) = {
-  if plain {
-    // Nothing left to carry the meaning, so the words do it — and they are the
-    // words the model already holds: code, docs, data, repo.
-    links.map(l => link(l.url, text(size: size * 0.86, fill: tint, l.label))).join([, ])
-  } else {
-    links.map(l => iconlink(l.url, l.icon, size: size, fill: tint)).join(h(3pt))
-  }
-}
 
 // ── one entry ─────────────────────────────────────────────────────────────
 // Title and subject share a line — "**Institution**, Role" — which is what
@@ -330,7 +249,7 @@
         .map(l => if l.label == l.rel {
           // The label is the bare rel — "paper", "repo" — which is a word the
           // mark was standing in for, so it serves when the mark is gone.
-          link(l.url, if plain { text(size: 0.9em, l.label) } else { icon(l.icon, size: 0.9em) })
+          link(l.url, solo(l.icon, l.label, size: 0.9em))
         } else {
           link(l.url, marked(l.icon, lnum(l.label), size: 0.9em))
         })

--- a/cv/lib/styles.typ
+++ b/cv/lib/styles.typ
@@ -1,0 +1,109 @@
+// The CV's styles — one self-contained unit each.
+//
+// A style answers three questions and nothing else:
+//
+//   glyph  how a mark is drawn beside words
+//   solo   how a mark standing alone is drawn, given the word behind it
+//   trail  how a run of marks — a resource trail — is drawn
+//
+// Everything else about the CV is the same in every style: the same type, the
+// same spacing, the same sections, from the same render model. That is why a
+// style is an entry in the dictionary below rather than a second template —
+// two templates would be two things to keep in agreement, and the page-count
+// contracts hold in either style only because the layout is shared.
+//
+// Adding one is an entry in STYLES and an <option> in
+// src/pages/cv/builder.astro. Nothing in cv.typ changes: it names no font, no
+// glyph and no style, and asks `styled()` for whichever one cv.json chose.
+
+#import "theme.typ": accent
+
+// ── the marks ─────────────────────────────────────────────────────────────
+// The same fonts the LaTeX CV uses — Font Awesome 5 Free Solid, its Brands
+// companion, and Academicons — vendored in public/fonts/. Real glyphs rather
+// than traced SVGs: they hint and scale like type, and they take a fill, so one
+// definition serves every colour.
+#let FA = "Font Awesome 5 Free Solid"
+#let FAB = "Font Awesome 5 Brands"
+#let AI = "Academicons"
+
+// name -> (family, codepoint), keyed by the names presets.json and REL_ICON use
+#let MARKS = (
+  // link trails
+  ads: (AI, "\u{E9CB}"),
+  arxiv: (AI, "\u{E974}"),
+  zenodo: (FA, "\u{F1C0}"), // \faIcon{database}, as in the LaTeX header
+  paper: (FA, "\u{F15C}"), // file-alt
+  repo: (FA, "\u{F6E3}"), // hammer — the reproducible-paper mark
+  github: (FAB, "\u{F09B}"),
+  code: (FA, "\u{F121}"),
+  docs: (FA, "\u{F05A}"), // info-circle
+  data: (FA, "\u{F1C0}"), // database
+  slides: (FA, "\u{F15C}"),
+  link: (FA, "\u{F0C1}"),
+  email: (FA, "\u{F0E0}"), // envelope
+  globe: (FA, "\u{F0AC}"),
+  orcid: (FAB, "\u{F8D2}"),
+  // section marks
+  education: (FA, "\u{F19C}"), // university
+  positions: (FA, "\u{F6FF}"), // network-wired
+  publications: (FA, "\u{F15C}"), // file-alt
+  awards: (FA, "\u{F559}"), // award
+  grants: (FA, "\u{F0D6}"), // money-bill
+  talks: (FA, "\u{F51C}"), // chalkboard-teacher
+  conferences: (FA, "\u{F0C0}"), // users
+  mentoring: (FA, "\u{E068}"), // people-arrows
+  teaching: (FA, "\u{F5D1}"), // apple-alt
+  service: (FA, "\u{F2B5}"), // handshake
+  panels: (FA, "\u{F0E3}"), // gavel
+  outreach: (FA, "\u{F234}"), // user-plus
+  media: (FA, "\u{F1EA}"), // newspaper
+)
+
+#let icon(name, size: 1em, fill: accent) = {
+  let (family, glyph) = MARKS.at(name, default: MARKS.link)
+  text(font: family, size: size, fill: fill, glyph)
+}
+
+// ── the styles ────────────────────────────────────────────────────────────
+#let STYLES = (
+  // What the pre-built PDFs are, and what the CLI always compiles.
+  default: (
+    glyph: (name, size: 1em, fill: accent) => icon(name, size: size, fill: fill),
+    solo: (name, word, size: 1em, fill: accent) => icon(name, size: size, fill: fill),
+    trail: (links, size: 1em, tint: accent) => links
+      .map(l => link(l.url, icon(l.icon, size: size, fill: tint)))
+      .join(h(3pt)),
+  ),
+
+  // The same CV with none of the marks — for anywhere a row of glyphs is
+  // unwelcome: a plain-text ATS, a printer that renders symbol fonts badly, or
+  // simply a preference. The PDF then embeds no icon font at all.
+  //
+  // Where a glyph stood beside words the words carry on alone; where one stood
+  // *by itself* the word it was standing in for takes its place, or the link
+  // would compile to nothing. Smaller than the mark it replaces: a word set at
+  // the glyph's optical size out-shouts the entry it belongs to.
+  plain: (
+    glyph: (name, size: 1em, fill: accent) => none,
+    solo: (name, word, size: 1em, fill: accent) => text(size: size, fill: fill, word),
+    trail: (links, size: 1em, tint: accent) => links
+      .map(l => link(l.url, text(size: size * 0.86, fill: tint, l.label)))
+      .join([, ]),
+  ),
+)
+
+/// The style cv.json names, with the one helper every style shares.
+///
+/// `marked` is derived rather than restated per style: a mark with words beside
+/// it is the same decision as the mark itself, so a style that answers `glyph`
+/// has already answered this, and the two cannot drift apart.
+#let styled(name) = {
+  let s = STYLES.at(name, default: STYLES.default)
+  s + (
+    marked: (name, body, size: 1em, fill: accent) => {
+      let g = (s.glyph)(name, size: size, fill: fill)
+      if g == none { body } else { [#g #body] }
+    },
+  )
+}

--- a/cv/lib/theme.typ
+++ b/cv/lib/theme.typ
@@ -1,0 +1,36 @@
+// The CV's palette and figures.
+//
+// Everything else in cv/ reads these: the template, and every style in
+// styles.typ. Split out so a colour is stated once and the styles have
+// somewhere to import it from rather than each carrying its own navy.
+//
+// The values come from starkman_long_cv.tex — one navy for every link, ORCID's
+// own green, and a grey for what qualifies rather than says.
+
+#let ink = rgb("#111111")
+#let accent = rgb("#003399") // linkcolour: rgb(0, 0.2, 0.6)
+#let faint = rgb("#808080") // \grayhref: gray 0.5
+#let orcid = rgb("#A6CE39") // orcidlogocol
+// The publication status pill, same two tints the website uses.
+#let accentsoft = rgb("#EAF0F9")
+#let accentline = rgb("#7FA6D9")
+// The header sits on this. Barely there by intent — enough to read as one
+// block rather than four columns that happen to be adjacent, not enough to
+// look like a filled panel, and light enough to survive an office printer
+// without banding.
+#let headerwash = luma(250)
+
+// ── figures ───────────────────────────────────────────────────────────────
+// The document is set in old-style figures (see cv.typ). These are the two
+// places that want something else back.
+
+// Lining and tabular: equal-width, cap-height digits, for the places where
+// figures form a column and have to align down the page rather than read as
+// part of a sentence.
+#let tnum(body) = text(number-type: "lining", number-width: "tabular", body)
+
+// Lining but proportional, for identifiers rather than columns. An ORCID iD, an
+// arXiv number or a postcode is transcribed digit by digit rather than read as
+// a quantity, and old-style figures — which vary in height by design — make
+// that harder for no gain.
+#let lnum(body) = text(number-type: "lining", body)

--- a/src/components/CollabMini.astro
+++ b/src/components/CollabMini.astro
@@ -10,51 +10,12 @@
 // of thirty-four people answer a question rather than just decorate. Here it
 // earns more than it does on /research/: the CV it sits beside is a list of
 // papers, so picking a collaborator can light up the ones we wrote together.
-import { collaboratorMap, lastFirst, map } from '../lib/collabmap.js';
+//
+// Markup only. The arithmetic is lib/collabmini.js and the behaviour is
+// lib/minipick.js, the same split CollabMap.astro makes.
+import { miniMap, map } from '../lib/collabmini.js';
 
-const people = collaboratorMap();
-
-// One dot per place per person. Within a person, four posts at one institution
-// are one dot — at this scale a rosette is just a darker pixel. Across people
-// the dots stack, which is why they are drawn opaque: two collaborators at the
-// same institution should read as one place, not as a darker one.
-const entries = people.map((person, c) => {
-  const at = new Map();
-  for (const pin of person.pins) {
-    const key = `${pin.x.toFixed(1)},${pin.y.toFixed(1)}`;
-    at.set(key, {
-      x: pin.x.toFixed(1),
-      y: pin.y.toFixed(1),
-      // Shared if anything was written during any post there.
-      shared: (at.get(key)?.shared ?? false) || pin.papers.length > 0,
-    });
-  }
-  // Every paper with this person, wherever they were standing. `unplacedPapers`
-  // are still collaborations — their ORCID just does not say where they were.
-  const papers = [...new Set([
-    ...person.pins.flatMap((p) => p.papers.map((q) => q.id)),
-    ...person.unplacedPapers.map((q) => q.id),
-  ])];
-  return { c, name: lastFirst(person.name), places: [...at.values()], papers };
-});
-
-// Surname first, so the picker reads like an index rather than a list of
-// first names — the same order the CV's own references are scanned in.
-entries.sort((a, b) => a.name.localeCompare(b.name));
-
-// Shared places last, so they are drawn over the plain ones rather than under.
-const dots = entries
-  .flatMap((e) => e.places.map((pl) => ({ ...pl, c: e.c })))
-  .sort((a, b) => Number(a.shared) - Number(b.shared));
-
-// One person's places joined in the order they held them — the same trajectory
-// the full map draws. `places` is already newest-first, because the dedup keeps
-// the order the pins came in and collaboratorMap sorts them that way.
-const trails = entries
-  .filter((e) => e.places.length > 1)
-  .map((e) => ({ c: e.c, points: e.places.map((pl) => `${pl.x},${pl.y}`).join(' ') }));
-
-const label = `${people.length} collaborators`;
+const { entries, dots, trails, label } = miniMap();
 ---
 
 <aside class="cvmini" id="cv-collab-map" hidden>
@@ -106,57 +67,6 @@ const label = `${people.length} collaborators`;
 </aside>
 
 <script>
-  // Picking a collaborator does two things at once, and the second is the point
-  // of putting this map next to a CV rather than on its own page: it narrows the
-  // map to where that person has worked, and it marks the papers in the list
-  // beside it that we wrote together.
-  //
-  // Progressive enhancement, as everywhere else here: with no JavaScript the map
-  // still draws every pin and the link still goes to the full version.
-  const aside = document.getElementById('cv-collab-map');
-  const pick = aside?.querySelector('.cvmini-who');
-
-  if (aside && pick) {
-    // Dots and trajectories alike — anything the map draws per person.
-    const drawn = [...aside.querySelectorAll('[data-c]')];
-    // Only the rows this CV actually rendered: a preset that drops a paper has
-    // no row to mark, which is not an error, just a shorter CV.
-    const rowFor = (id) => document.getElementById(`item-${id}`);
-
-    let marked = [];
-
-    /** The green rows, which live outside this aside and so must be cleaned up
-     *  explicitly. A mark with no map to explain it is just an unexplained
-     *  green row, so nothing is marked while the map is shut. */
-    const markPapers = () => {
-      for (const row of marked) row.classList.remove('is-coauthor');
-      marked = [];
-      if (aside.hidden || pick.value === '') return;
-
-      const opt = pick.options[pick.selectedIndex];
-      for (const id of (opt.dataset.papers || '').split(' ').filter(Boolean)) {
-        const row = rowFor(id);
-        if (row) { row.classList.add('is-coauthor'); marked.push(row); }
-      }
-    };
-
-    const show = (only) => {
-      for (const d of drawn) d.style.display = only === '' || d.dataset.c === only ? '' : 'none';
-      // The stylesheet brings the surviving trajectory up from its resting
-      // faintness; expressed as one attribute rather than a class per element.
-      if (only === '') delete aside.dataset.only;
-      else aside.dataset.only = only;
-      markPapers();
-    };
-
-    pick.addEventListener('change', () => show(pick.value));
-
-    // The button that opens and shuts the map belongs to the CV, not to this
-    // component, so watch the attribute rather than reaching for the button:
-    // whoever hides the aside — that button, a future one, or a stylesheet
-    // change — the marks go with it, and the selection is honoured again when
-    // it reopens.
-    new MutationObserver(markPapers)
-      .observe(aside, { attributes: true, attributeFilter: ['hidden'] });
-  }
+  import { wireMiniMap } from '../lib/minipick.js';
+  wireMiniMap();
 </script>

--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -148,7 +148,9 @@ const money = (a) => {
       {/* In the `}` gutter, centred on the column where each paper's source
           link sits, so it reads as part of that column rather than as another
           control on the heading row. Publications only: the map is about the
-          people in these bylines. */}
+          people in these bylines. The button is rendered here because it
+          belongs to this row; what it does is in lib/minipick.js, with the map
+          it opens and with the panel's own copy of it. */}
       {s.id === 'publications' && (
         <button type="button" class="cvminibtn" aria-expanded="false" aria-controls="cv-collab-map"
                 aria-label="Show where my collaborators have worked"
@@ -310,31 +312,6 @@ const money = (a) => {
     a.addEventListener('click', () => {
       if (!heads.length) return;
       sessionStorage.setItem(KEY, JSON.stringify(anchorTrail(rects(), topGap)));
-    });
-  }
-
-  // The gutter map. Off until asked for, because the CV is the thing on this
-  // page and a map beside the publications is an aside to it. `hidden` rather
-  // than a class, so with the map closed a screen reader is told the same thing
-  // the eye is, and the button's aria-expanded says which way it is.
-  const mapBtn = document.querySelector('.cvminibtn');
-  const mapAside = document.getElementById('cv-collab-map');
-  if (mapBtn && mapAside) {
-    const setOpen = (open) => {
-      mapAside.hidden = !open;
-      mapBtn.setAttribute('aria-expanded', String(open));
-      const what = open ? 'Hide' : 'Show';
-      mapBtn.setAttribute('aria-label', `${what} where my collaborators have worked`);
-      mapBtn.setAttribute('title', `${what} where my collaborators have worked`);
-    };
-    mapBtn.addEventListener('click', () => setOpen(mapAside.hidden));
-    // The panel's own copy of the button only ever shuts it — it is inside the
-    // thing it hides. Focus goes back to the heading's button, because closing
-    // has just removed the focused element from the page; `preventScroll`
-    // because the point of the second button is that the heading is far above.
-    mapAside.querySelector('.cvmini-shut')?.addEventListener('click', () => {
-      setOpen(false);
-      mapBtn.focus({ preventScroll: true });
     });
   }
 

--- a/src/lib/collabmini.js
+++ b/src/lib/collabmini.js
@@ -1,0 +1,67 @@
+// The collaborator map's render model, shrunk to the CV's right margin.
+//
+// Same people, same projection, same paper links as collabmap.js — imported,
+// not reimplemented, so the two maps cannot disagree about where anyone worked.
+// What differs is everything the size decides: at 176px a rosette is a darker
+// pixel and a paper title is unreadable, so a person is a handful of places and
+// a list of paper ids, and the prose stays on /research/.
+//
+// Resolved here rather than in the component for the reason collabmap.js is:
+// the page then renders plain numbers, and the arithmetic is testable without
+// a DOM.
+
+import { collaboratorMap, lastFirst } from './collabmap.js';
+
+export { map } from './collabmap.js';
+
+/** One dot per place per person, one trail per person who moved, and the paper
+ *  ids each person shares with me — the three things the gutter map draws. */
+export function miniMap() {
+  const people = collaboratorMap();
+
+  // Within a person, four posts at one institution are one dot. Across people
+  // the dots stack, which is why they are drawn opaque: two collaborators at
+  // the same institution should read as one place, not as a darker one.
+  const entries = people.map((person, c) => {
+    const at = new Map();
+    for (const pin of person.pins) {
+      const key = `${pin.x.toFixed(1)},${pin.y.toFixed(1)}`;
+      at.set(key, {
+        x: pin.x.toFixed(1),
+        y: pin.y.toFixed(1),
+        // Shared if anything was written during any post there.
+        shared: (at.get(key)?.shared ?? false) || pin.papers.length > 0,
+      });
+    }
+    // Every paper with this person, wherever they were standing.
+    // `unplacedPapers` are still collaborations — their ORCID just does not say
+    // where they were.
+    const papers = [...new Set([
+      ...person.pins.flatMap((p) => p.papers.map((q) => q.id)),
+      ...person.unplacedPapers.map((q) => q.id),
+    ])];
+    return { c, name: lastFirst(person.name), places: [...at.values()], papers };
+  });
+
+  // Surname first, so the picker reads like an index rather than a list of
+  // first names — the same order the CV's own references are scanned in. `c`
+  // stays the collaboratorMap index it started as: it is what the dots and the
+  // trails are keyed by, so re-ordering the picker must not renumber them.
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    entries,
+    // Shared places last, so they are drawn over the plain ones rather than under.
+    dots: entries
+      .flatMap((e) => e.places.map((pl) => ({ ...pl, c: e.c })))
+      .sort((a, b) => Number(a.shared) - Number(b.shared)),
+    // One person's places joined in the order they held them — the same
+    // trajectory the full map draws. `places` is already newest-first, because
+    // the dedup keeps the order the pins came in and collaboratorMap sorts them
+    // that way.
+    trails: entries
+      .filter((e) => e.places.length > 1)
+      .map((e) => ({ c: e.c, points: e.places.map((pl) => `${pl.x},${pl.y}`).join(' ') })),
+    label: `${people.length} collaborators`,
+  };
+}

--- a/src/lib/minipick.js
+++ b/src/lib/minipick.js
@@ -1,0 +1,93 @@
+// The gutter map's behaviour: opening it, picking someone, and marking what we
+// wrote together.
+//
+// mappick.js's counterpart. Not the same module, because this is not the same
+// interaction: the full maps pair a picker with a roster and dim between the
+// two halves, while this one has no roster and instead reaches out of its own
+// aside into the CV beside it. Sharing one module would mean each page
+// shipping the other's behaviour to run neither.
+//
+// Progressive enhancement, as everywhere else here: with no JavaScript the map
+// still draws every pin and the link still goes to the full version.
+
+/**
+ * Wire the CV's gutter map. Idempotent, and silent when the map is not on the
+ * page — a preset that renders no publications section renders no map either.
+ *
+ * @param {string} id the aside's element id — what the two buttons that work
+ *   it name in `aria-controls`.
+ */
+export function wireMiniMap(id = 'cv-collab-map') {
+  const aside = document.getElementById(id);
+  const pick = aside?.querySelector('.cvmini-who');
+  if (!aside || !pick || aside.dataset.wired) return;
+  aside.dataset.wired = '1';
+
+  // Dots and trajectories alike — anything the map draws per person.
+  const drawn = [...aside.querySelectorAll('[data-c]')];
+  // Only the rows this CV actually rendered: a preset that drops a paper has no
+  // row to mark, which is not an error, just a shorter CV.
+  const rowFor = (paper) => document.getElementById(`item-${paper}`);
+
+  let marked = [];
+
+  /** The marked rows, which live outside this aside and so must be cleaned up
+   *  explicitly. A mark with no map to explain it is just an unexplained green
+   *  row, so nothing is marked while the map is shut. */
+  const markPapers = () => {
+    for (const row of marked) row.classList.remove('is-coauthor');
+    marked = [];
+    if (aside.hidden || pick.value === '') return;
+
+    const opt = pick.options[pick.selectedIndex];
+    for (const paper of (opt.dataset.papers || '').split(' ').filter(Boolean)) {
+      const row = rowFor(paper);
+      if (row) { row.classList.add('is-coauthor'); marked.push(row); }
+    }
+  };
+
+  // Picking a collaborator does two things at once, and the second is the point
+  // of putting this map next to a CV rather than on its own page: it narrows
+  // the map to where that person has worked, and it marks the papers in the
+  // list beside it that we wrote together.
+  pick.addEventListener('change', () => {
+    const only = pick.value;
+    for (const d of drawn) d.style.display = only === '' || d.dataset.c === only ? '' : 'none';
+    // The stylesheet brings the surviving trajectory up from its resting
+    // faintness; expressed as one attribute rather than a class per element.
+    if (only === '') delete aside.dataset.only;
+    else aside.dataset.only = only;
+    markPapers();
+  });
+
+  // The button that opens the map belongs to the CV's heading row, where a
+  // paper's source mark sits — it cannot live inside an aside that is
+  // positioned into the margin. Its behaviour can, and does, so all of the
+  // map's client code is this file.
+  const btn = document.querySelector('.cvminibtn');
+  // `hidden` rather than a class, so with the map closed a screen reader is
+  // told the same thing the eye is, and `aria-expanded` says which way it is.
+  const setOpen = (open) => {
+    aside.hidden = !open;
+    btn.setAttribute('aria-expanded', String(open));
+    const words = `${open ? 'Hide' : 'Show'} where my collaborators have worked`;
+    btn.setAttribute('aria-label', words);
+    btn.setAttribute('title', words);
+  };
+  btn?.addEventListener('click', () => setOpen(aside.hidden));
+
+  // The panel's own copy of the button only ever shuts it — it is inside the
+  // thing it hides. Focus goes back to the heading's button, because closing
+  // has just removed the focused element from the page; `preventScroll`
+  // because the point of the second button is that the heading is far above.
+  aside.querySelector('.cvmini-shut')?.addEventListener('click', () => {
+    setOpen(false);
+    btn.focus({ preventScroll: true });
+  });
+
+  // Watch the attribute rather than calling markPapers from the handler above:
+  // whoever hides the aside — that button, a future one, or a stylesheet change
+  // — the marks go with it, and the selection is honoured again when it reopens.
+  new MutationObserver(markPapers)
+    .observe(aside, { attributes: true, attributeFilter: ['hidden'] });
+}

--- a/src/pages/cv/builder.astro
+++ b/src/pages/cv/builder.astro
@@ -83,11 +83,13 @@ const site = buildInfo();
   <script>
     import { cvModel } from '../../lib/cvmodel.js';
     import { encode, decode } from '../../lib/selection.js';
-    import typSource from '../../../cv/cv.typ?raw';
-    // cv.typ draws its marks with image("icons/…"), which resolves against the
-    // compilation root: cv/icons/ under the CLI, /icons/ here. Bundled at build
-    // time rather than fetched, so compiling stays one round trip.
-    // The header's portrait and QR are binary and live beside the marks.
+    // The whole template, not just cv.typ: it imports lib/theme.typ and
+    // lib/styles.typ, and typst.ts resolves those against the same virtual root.
+    // Globbed rather than listed, so adding a module — or a style — needs no
+    // change here.
+    const TEMPLATE = import.meta.glob('/cv/**/*.typ', { eager: true, query: '?raw', import: 'default' });
+    // The header's portrait and QR are binary and live beside the template.
+    // Bundled at build time rather than fetched, so compiling stays one round trip.
     const ASSETS = import.meta.glob('/cv/assets/*', { eager: true, query: '?url', import: 'default' });
 
     const $ = (id) => document.getElementById(id);
@@ -401,7 +403,11 @@ const site = buildInfo();
             .add(Number(b.dataset.line));
         }
         const model = cvModel('complete', chosen, (id, i) => keep.get(id)?.has(i) ?? false);
-        await t.addSource('/cv.typ', typSource);
+        // cv/ is the compilation root in both runtimes, so cv/lib/styles.typ is
+        // /lib/styles.typ here and the relative imports inside resolve unchanged.
+        for (const [path, src] of Object.entries(TEMPLATE)) {
+          await t.addSource(path.slice('/cv'.length), src);
+        }
         for (const [path, url] of Object.entries(ASSETS)) {
           const bytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
           await t.mapShadow(`/assets/${path.split('/').pop()}`, bytes);

--- a/tests/collabmini.test.js
+++ b/tests/collabmini.test.js
@@ -1,0 +1,81 @@
+// The gutter map is a lossy view of the collaborator map, and every loss is a
+// deliberate one: places collapse, trails need two of them, and papers written
+// where ORCID names no post are still papers. These are the assertions that
+// say so.
+
+import { describe, it, expect } from 'vitest';
+import { collaboratorMap, lastFirst } from '../src/lib/collabmap.js';
+import { miniMap } from '../src/lib/collabmini.js';
+
+const people = collaboratorMap();
+const { entries, dots, trails } = miniMap();
+// Every entry keeps the index of the person it came from; the picker's order
+// is not that index, which is the point of the test below.
+const who = (e) => people[e.c];
+
+describe('the CV gutter map', () => {
+  it('keeps one entry per collaborator', () => {
+    expect(entries.length).toBe(people.length);
+    expect(new Set(entries.map((e) => e.c)).size).toBe(people.length);
+  });
+
+  it('lists them surname-first, in that order', () => {
+    expect(entries.map((e) => e.name))
+      .toEqual([...people.map((p) => lastFirst(p.name))].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('does not renumber anyone when it sorts them', () => {
+    // `c` keys the dots and the trails, so a sort that renumbered would move
+    // every pin on the map to the wrong person without looking wrong.
+    for (const e of entries) expect(e.name).toBe(lastFirst(who(e).name));
+    // And the sort really does reorder, or this proves nothing.
+    expect(entries.map((e) => e.c)).not.toEqual(people.map((_, i) => i));
+  });
+
+  it('collapses a person\'s repeat posts at one place into one dot', () => {
+    // Four posts at one institution are one dot: at this size a rosette is
+    // just a darker pixel.
+    for (const e of entries) {
+      expect(e.places.length).toBeLessThanOrEqual(who(e).pins.length);
+      const keys = e.places.map((pl) => `${pl.x},${pl.y}`);
+      expect(new Set(keys).size).toBe(keys.length);
+    }
+    // And it must actually be collapsing something, or the test proves nothing.
+    expect(entries.some((e) => e.places.length < who(e).pins.length)).toBe(true);
+  });
+
+  it('counts a place as shared if anything was written during any post there', () => {
+    for (const e of entries) {
+      for (const place of e.places) {
+        const here = who(e).pins.filter((pin) => pin.x.toFixed(1) === place.x
+          && pin.y.toFixed(1) === place.y);
+        expect(place.shared).toBe(here.some((pin) => pin.papers.length > 0));
+      }
+    }
+    expect(dots.some((d) => d.shared)).toBe(true);
+  });
+
+  it('draws the shared dots last, so they sit over the plain ones', () => {
+    const first = dots.findIndex((d) => d.shared);
+    expect(dots.slice(first).every((d) => d.shared)).toBe(true);
+  });
+
+  it('draws a trail only for someone who moved', () => {
+    expect(trails.map((t) => t.c))
+      .toEqual(entries.filter((e) => e.places.length > 1).map((e) => e.c));
+    for (const t of trails) expect(t.points.split(' ').length).toBeGreaterThan(1);
+  });
+
+  it('marks every shared paper, including the ones ORCID cannot place', () => {
+    for (const e of entries) {
+      const placed = who(e).pins.flatMap((pin) => pin.papers.map((q) => q.id));
+      const unplaced = who(e).unplacedPapers.map((q) => q.id);
+      expect(new Set(e.papers)).toEqual(new Set([...placed, ...unplaced]));
+      // The ids go into one space-separated attribute, so an id with a space
+      // in it would silently mark two rows and miss the one it meant.
+      for (const id of e.papers) expect(id).not.toMatch(/\s/);
+    }
+    // Unplaced papers exist in the data, so this is not vacuous.
+    expect(people.some((p) => p.unplacedPapers.length > 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Changing code or schema

**What and why:**

Code cleanup only — no behaviour changes, no data changes, no schema changes.

### The CV's styles

A style was a `plain` boolean and four `if` branches scattered through
`cv.typ`; adding a third meant finding all four. A style is now one entry in
`STYLES` in [`cv/lib/styles.typ`](cv/lib/styles.typ), answering three questions
and nothing else:

| the unit answers | asked by |
|---|---|
| `glyph(name)` | a mark drawn beside words — a section heading, a contact line |
| `solo(name, word)` | a mark standing *alone*, given the word it stood in for — a bare `arXiv` link |
| `trail(links)` | a run of marks — the `code, docs, data` trail at the end of an entry |

`marked()` is derived from `glyph` rather than restated, so a style cannot
answer those two inconsistently. The palette and the two non-old-style figure
helpers move to [`cv/lib/theme.typ`](cv/lib/theme.typ), which is where the
styles import their navy from — so `cv.typ` now names no colour, no font and
no glyph, and adding a style never touches it.

The builder globs `/cv/**/*.typ` into typst.ts's virtual filesystem instead of
naming `cv.typ`, so a new module needs no change there either. `cv/` is the
compilation root in both runtimes, so the relative imports resolve unchanged.

The README's **The CV** section gains a table of the three files, links to
each, and documents what a style unit has to answer.

### The gutter map

Made the split the other two maps on the site already make:

- `src/lib/collabmini.js` — the model: dot dedup, trail points, shared-paper ids
- `src/lib/minipick.js` — the behaviour, `mappick.js`'s counterpart
- `CollabMini.astro` — markup

The open/shut button's handler moves out of `CvView.astro` to sit with the map
it opens, so all of the minimap's client code is one file. The button's markup
stays in the heading row, where it has to be.

### Verification

- Every page of all four presets in **both** styles renders **pixel-identical**
  to pre-refactor (rendered at 100 dpi and hash-compared), and the one- and
  two-page contracts still hold.
- The in-browser builder compiles both styles from the split template — checked
  against a production build, since it is the only path the test suite cannot
  reach.
- The gutter map still opens, narrows to one person, marks the papers we wrote
  together, clears them when shut, and restores the selection when reopened.
- `tests/collabmini.test.js` covers what the shrinking loses on purpose —
  places collapsing, trails needing two of them, and papers ORCID cannot place
  still counting as shared. Each assertion has a companion check that the data
  actually exercises it.

- [x] `npm run test:schema` passes
- [x] If a `link.rel` value or a `type` was added, every renderer was updated in this PR — n/a
- [x] If a constraint was added, `schema/invalid/` gained a fixture proving it is enforced — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)