### PR TITLE
A second way to shut the gutter map, inside the gutter map

### DIFF
--- a/src/components/CollabMini.astro
+++ b/src/components/CollabMini.astro
@@ -59,9 +59,20 @@ const label = `${people.length} collaborators`;
 
 <aside class="cvmini" id="cv-collab-map" hidden>
   <div class="cvmini-stick">
-    {/* At the top and right-aligned, so the arrow points out of the panel the
-        way the "All X →" links do elsewhere on the site. */}
-    <a class="cvmini-more" href="/research/#collaborators">Expanded View &rarr;</a>
+    {/* The arrow is right-aligned, pointing out of the panel the way the
+        "All X →" links do elsewhere on the site. Facing it is a second copy of
+        the button that opened the map: that one rides on the Publications
+        heading and scrolls away with it, and a panel that sticks to the
+        viewport must be closable from where it is, not from where it started. */}
+    <div class="cvmini-top">
+      <button type="button" class="cvmini-shut" aria-controls="cv-collab-map"
+              aria-expanded="true"
+              aria-label="Hide where my collaborators have worked"
+              title="Hide where my collaborators have worked">
+        <svg class="ico" aria-hidden="true" focusable="false"><use href="#i-map" /></svg>
+      </button>
+      <a class="cvmini-more" href="/research/#collaborators">Expanded View &rarr;</a>
+    </div>
 
     <svg class="cvmini-svg" viewBox={`0 0 ${map.width} ${map.height}`} role="img"
          aria-label={`Map: where ${label} have worked. The same information is on the collaborator page.`}>

--- a/src/components/CvView.astro
+++ b/src/components/CvView.astro
@@ -320,13 +320,21 @@ const money = (a) => {
   const mapBtn = document.querySelector('.cvminibtn');
   const mapAside = document.getElementById('cv-collab-map');
   if (mapBtn && mapAside) {
-    mapBtn.addEventListener('click', () => {
-      const open = mapAside.hidden;
+    const setOpen = (open) => {
       mapAside.hidden = !open;
       mapBtn.setAttribute('aria-expanded', String(open));
       const what = open ? 'Hide' : 'Show';
       mapBtn.setAttribute('aria-label', `${what} where my collaborators have worked`);
       mapBtn.setAttribute('title', `${what} where my collaborators have worked`);
+    };
+    mapBtn.addEventListener('click', () => setOpen(mapAside.hidden));
+    // The panel's own copy of the button only ever shuts it — it is inside the
+    // thing it hides. Focus goes back to the heading's button, because closing
+    // has just removed the focused element from the page; `preventScroll`
+    // because the point of the second button is that the heading is far above.
+    mapAside.querySelector('.cvmini-shut')?.addEventListener('click', () => {
+      setOpen(false);
+      mapBtn.focus({ preventScroll: true });
     });
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1056,16 +1056,24 @@ nav ul a.on:hover{color:var(--accent); border-color:var(--accent)}
      left edge and the icon 6.6px to the right of the column it belongs to.
      Half the mark's advance — 0.68rem of mono, so ~0.41rem wide — brings the
      centres together, and translateX(-50%) does the rest. */
-  .cvminibtn{
-    display:block; position:absolute; left:100%; top:50%;
-    transform:translate(-50%, -50%);
-    margin-left:calc(1.5rem + 0.2rem); padding:.15rem; line-height:0;
+  /* The same control in two places — on the heading and in the panel — so it
+     is one set of rules and only the positioning differs. */
+  .cvminibtn, .cvmini-shut{
+    display:block; padding:.15rem; line-height:0;
     background:none; border:0; cursor:pointer;
     color:var(--ink-faint); opacity:.4; transition:opacity .15s, color .15s;
   }
-  .cvminibtn:hover, .cvminibtn:focus-visible{opacity:1; color:var(--accent)}
-  .cvminibtn .ico{width:15px; height:15px; fill:currentColor; display:block}
-  .cvminibtn[aria-expanded="true"]{opacity:1; color:var(--accent)}
+  .cvminibtn{
+    position:absolute; left:100%; top:50%;
+    transform:translate(-50%, -50%);
+    margin-left:calc(1.5rem + 0.2rem);
+  }
+  .cvminibtn:hover, .cvminibtn:focus-visible,
+  .cvmini-shut:hover, .cvmini-shut:focus-visible{opacity:1; color:var(--accent)}
+  .cvminibtn .ico, .cvmini-shut .ico{width:15px; height:15px; fill:currentColor; display:block}
+  /* Lit while the map is open, which for the panel's copy is always: it is
+     inside the thing it closes. */
+  .cvminibtn[aria-expanded="true"], .cvmini-shut{opacity:1; color:var(--accent)}
 
   .cvsec--hasmap{position:relative}
   /* Absolute so it takes no space in the column, full height so the sticky
@@ -1106,8 +1114,11 @@ nav ul a.on:hover{color:var(--accent); border-color:var(--accent)}
 
   .cvmini-svg circle{fill:var(--ink-mute); fill-opacity:.55}
   .cvmini-svg circle.is-shared{fill:var(--accent); fill-opacity:.9}
+  /* Button left, link right, baseline-aligned on one row above the map. */
+  .cvmini-top{display:flex; align-items:center; justify-content:space-between;
+    gap:.4rem; margin:0 0 .4rem}
   .cvmini-more{
-    display:block; margin:0 0 .4rem; font-size:.7rem; line-height:1.35;
+    font-size:.7rem; line-height:1.35;
     color:var(--ink-faint); text-align:right;
   }
   .cvmini-more:hover, .cvmini-more:focus-visible{color:var(--accent)}


### PR DESCRIPTION
## Changing code or schema

**What and why:**

The button that opens the CV's collaborator map rides on the Publications
heading. The panel it opens is sticky and travels the whole section, so a
screen or two down the map is still there and the only way to dismiss it is to
scroll back up to the heading — which is the thing the sticky panel exists to
avoid.

So the same map icon appears again in the panel's own top-left, facing the
"Expanded View →" link across one row above the map. It only ever closes: it is
inside the thing it hides.

- One `setOpen` now drives both buttons, so the heading's button cannot go on
  claiming `aria-expanded="true"` for a map that is shut.
- Focus returns to the heading's button on close — the closed element was
  holding it — with `preventScroll`, because the whole point of the second
  button is that the heading is far above.
- The two buttons share one set of rules; only the positioning differs.

Verified at 1400px on `/cv/` and, scrolled deep into the picker, on
`/cv/builder/`: the button sits flush with the map's left edge at the sticky
top (y=105 under the bars), closing syncs the heading button's label and
`aria-expanded`, the page does not move, and the green co-author marks clear on
close and come back on reopen.

- [x] `npm run test:schema` passes
- [x] If a `link.rel` value or a `type` was added, every renderer was updated in this PR — n/a
- [x] If a constraint was added, `schema/invalid/` gained a fixture proving it is enforced — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)