### PR TITLE
Refresh the contributions list

### DIFF
--- a/config/contributions.json
+++ b/config/contributions.json
@@ -206,14 +206,6 @@
       "description": "Composable transformations of Python+NumPy programs: differentiate, vectorize, JIT to GPU/TPU, and more"
     },
     {
-      "repo": "GalacticDynamics/galax.inference",
-      "url": "https://github.com/GalacticDynamics/galax.inference",
-      "first": "2024-03-07",
-      "prs": 13,
-      "description": null,
-      "archived": true
-    },
-    {
       "repo": "patrick-kidger/equinox",
       "url": "https://github.com/patrick-kidger/equinox",
       "first": "2024-06-17",


### PR DESCRIPTION
Found by `scripts/collect-contributions.mjs`, run monthly by `.github/workflows/refresh-contributions.yml`.

The list now holds 45 repositories.

To drop one, add it to `config/contributions-exclude.json` — do not edit the generated file.